### PR TITLE
Nova Implementação Patch e Migração .NET Standard 2.1 para StandardHttpClient

### DIFF
--- a/src/Nuuvify.CommonPack.StandardHttpClient/Implementation/StandardHttpClientVerbs.cs
+++ b/src/Nuuvify.CommonPack.StandardHttpClient/Implementation/StandardHttpClientVerbs.cs
@@ -126,9 +126,20 @@ namespace Nuuvify.CommonPack.StandardHttpClient
 
         public async Task<HttpStandardReturn> Patch(string urlRoute, object messageBody, CancellationToken cancellationToken = default)
         {
+            var url = $"{urlRoute}{_queryString.ToQueryString()}";
 
-            var patch = await Put(urlRoute, messageBody);
-            return patch;
+
+            var message = new HttpRequestMessage(HttpMethod.Patch, url)
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(messageBody),
+                    Encoding.UTF8, "application/json"
+                )
+            }
+            .CustomRequestHeader(_headerStandard)
+            .AddAuthorizationHeader(_headerAuthorization);
+
+            return await StandardSendAsync(url, message, cancellationToken);
 
         }
 

--- a/src/Nuuvify.CommonPack.StandardHttpClient/Nuuvify.CommonPack.StandardHttpClient.csproj
+++ b/src/Nuuvify.CommonPack.StandardHttpClient/Nuuvify.CommonPack.StandardHttpClient.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Description>
       Possui classes para padronizar a comunicação com apis externas, padronizando inclusive o
       retorno da request.

--- a/test/Nuuvify.CommonPack.StandardHttpClient.xTest/StandardHttpClientTests.cs
+++ b/test/Nuuvify.CommonPack.StandardHttpClient.xTest/StandardHttpClientTests.cs
@@ -148,6 +148,56 @@ namespace Nuuvify.CommonPack.StandardHttpClient.xTest
 
         }
 
+        [Fact, Order(4)]
+        public void PatchApiRealDeveRetornarMensagemComSucesso()
+        {
+            var resultDefault = new HttpStandardReturn
+            {
+                ReturnCode = "200",
+                ReturnMessage = "Alterado com sucesso",
+                Success = true
+            };
+
+            var jsonConverted = JsonSerializer.Serialize(resultDefault);
+
+            var clientHandlerStub = new DelegatingHandlerStub(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(jsonConverted, Encoding.UTF8, "application/json")
+            });
+
+            var client = new HttpClient(clientHandlerStub, true)
+            {
+                BaseAddress = new Uri("https://meuteste/")
+            };
+            client.DefaultRequestHeaders.Add("Accept", "application/json");
+
+
+            mockFactory.Setup(_ => _.CreateClient(It.IsAny<string>())).Returns(client);
+
+            var url = "api/cliente";
+
+            var standardClient = new StandardHttpClient(mockFactory.Object, new NullLogger<StandardHttpClient>());
+            standardClient.CreateClient();
+            standardClient.ResetStandardHttpClient();
+            var fakeClass = new FakeClasseRetorno
+            {
+                Codigo = 123456,
+                DataCadastro = DateTime.Now,
+                Descricao = "Isso é um teste"
+            };
+
+            var result = standardClient
+                .WithHeader("Accept-Language", "pt-BR")
+                .WithCurrelationHeader("zxzxzxzxzxzxzxzxzxz")
+                .WithAuthorization("bearer", "xyz")
+                .Patch(url, fakeClass).Result;
+
+
+            Assert.Equal(resultDefault.ReturnCode, result.ReturnCode);
+
+        }
+
         [Fact]
         public void RecebeLoginDiferente_DeveSubstituirDados()
         {


### PR DESCRIPTION
Eu fiz uma alteração na implementação do método HTTP Patch. Agora, em vez de chamar o método Put, ele faz, de fato, uma chamada Patch. 

Como a classe System.Net.Http.HttpMethod do .NET Standard 2.0 não suporta o método Patch, fiz a migração da biblioteca para o .NET Standard 2.1.

Issue Relacionada: #54 