### PR TITLE
feat(unitofwork): add worker short-lived DbContext factory, docs updates, and test stabilization

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,6 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2.5.0-preview.1"
+version = "2.4.0-preview.1"
 version_scheme = "semver2"
 bump_message = "chore(release): bump from $current_version to $new_version [skip ci]"
 annotated_tag = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/spec
 ### Adicionado
 - Suporte a `ReceiveMode` em componentes de consumo do Azure Service Bus (`Nuuvify.CommonPack.AzureServiceBus` e `Nuuvify.CommonPack.BackgroundService`).
 - Suporte a CNPJ alfanumérico no pacote `Nuuvify.CommonPack.Domain`.
+- Suporte opt-in a `IUnitOfWorkFactory<TContext>` no pacote `Nuuvify.CommonPack.UnitOfWork` para criação de `UnitOfWork` curto por operação com `IDbContextFactory<TContext>`.
+- Suporte opt-in a `IShortLivedDbContextFactory<TContext>` e `IWorkerDbContextFactory<TContext>` no pacote `Nuuvify.CommonPack.UnitOfWork` para criação de `DbContext` curto com auditoria em cenários de worker/background.
 
 ### Alterado
 - Geração de Id em `DomainEntity` no pacote `Nuuvify.CommonPack.Extensions` alterada para UUID orientado a banco de dados (UUID v7).

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
         <PackageProjectUrl>https://github.com/lzocateli/Nuuvify.CommonPack</PackageProjectUrl>
         <PackageIcon>logonuuvify.jpg</PackageIcon>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <Version>2.5.0</Version>
+        <Version>2.4.0</Version>
         <FileVersion>1520</FileVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>1701;1702;1705;1591</NoWarn>

--- a/src/Nuuvify.CommonPack.UnitOfWork.Abstraction/CHANGELOG.md
+++ b/src/Nuuvify.CommonPack.UnitOfWork.Abstraction/CHANGELOG.md
@@ -8,6 +8,8 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/spec
 ## [Não Lançado]
 
 ### Adicionado
+- Nova interface `IShortLivedDbContextFactory<TContext>` para criação explícita de contexto EF curto por operação com suporte a auditoria (`usernameContext`/`userIdContext`).
+- Nova interface `IWorkerDbContextFactory<TContext>` para cenários de worker/background com contrato especializado sobre contexto EF curto.
 
 ### Alterado
 

--- a/src/Nuuvify.CommonPack.UnitOfWork.Abstraction/Interfaces/IShortLivedDbContextFactoryOfT.cs
+++ b/src/Nuuvify.CommonPack.UnitOfWork.Abstraction/Interfaces/IShortLivedDbContextFactoryOfT.cs
@@ -1,0 +1,21 @@
+namespace Nuuvify.CommonPack.UnitOfWork.Abstraction.Interfaces;
+
+/// <summary>
+/// Defines an opt-in factory for creating short-lived DbContext instances with optional audit context.
+/// </summary>
+/// <typeparam name="TContext">The db context type handled by the factory.</typeparam>
+public interface IShortLivedDbContextFactory<TContext>
+    where TContext : class
+{
+    /// <summary>
+    /// Creates a new independent short-lived db context instance.
+    /// </summary>
+    /// <param name="usernameContext">Optional username used for audit context.</param>
+    /// <param name="userIdContext">Optional user identifier used for audit context.</param>
+    /// <param name="cancellationToken">Cancellation token for context creation.</param>
+    /// <returns>A new short-lived db context.</returns>
+    Task<TContext> CreateAsync(
+        string usernameContext = null,
+        string userIdContext = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Nuuvify.CommonPack.UnitOfWork.Abstraction/Interfaces/IUnitOfWorkFactoryOfT.cs
+++ b/src/Nuuvify.CommonPack.UnitOfWork.Abstraction/Interfaces/IUnitOfWorkFactoryOfT.cs
@@ -1,0 +1,20 @@
+namespace Nuuvify.CommonPack.UnitOfWork.Abstraction.Interfaces;
+
+/// <summary>
+/// Defines an opt-in factory for creating short-lived <see cref="IUnitOfWork{TContext}"/> instances.
+/// </summary>
+/// <typeparam name="TContext">The db context type handled by the unit of work.</typeparam>
+public interface IUnitOfWorkFactory<TContext> where TContext : class
+{
+    /// <summary>
+    /// Creates a new independent <see cref="IUnitOfWork{TContext}"/> instance.
+    /// </summary>
+    /// <param name="usernameContext">Optional username used for audit context.</param>
+    /// <param name="userIdContext">Optional user identifier used for audit context.</param>
+    /// <param name="cancellationToken">Cancellation token for context creation.</param>
+    /// <returns>A new short-lived unit of work.</returns>
+    Task<IUnitOfWork<TContext>> CreateAsync(
+        string usernameContext = null,
+        string userIdContext = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Nuuvify.CommonPack.UnitOfWork.Abstraction/Interfaces/IWorkerDbContextFactoryOfT.cs
+++ b/src/Nuuvify.CommonPack.UnitOfWork.Abstraction/Interfaces/IWorkerDbContextFactoryOfT.cs
@@ -1,0 +1,10 @@
+namespace Nuuvify.CommonPack.UnitOfWork.Abstraction.Interfaces;
+
+/// <summary>
+/// Defines an opt-in factory for creating short-lived db context instances for worker/background flows.
+/// </summary>
+/// <typeparam name="TContext">The db context type handled by the factory.</typeparam>
+public interface IWorkerDbContextFactory<TContext> : IShortLivedDbContextFactory<TContext>
+    where TContext : class
+{
+}

--- a/src/Nuuvify.CommonPack.UnitOfWork/CHANGELOG.md
+++ b/src/Nuuvify.CommonPack.UnitOfWork/CHANGELOG.md
@@ -8,14 +8,30 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/spec
 ## [Não Lançado]
 
 ### Adicionado
+- Nova implementação `ShortLivedDbContextFactory<TContext>` para criação de `DbContext` curto por operação, com aplicação opcional de auditoria no contexto criado.
+- Nova extensão de DI `AddShortLivedDbContextFactory<TContext>()` para registrar a factory genérica de contexto curto.
+- Nova implementação `WorkerDbContextFactory<TContext>` para cenários de worker/background e extensão de DI `AddWorkerDbContextFactory<TContext>()`.
 
 ### Alterado
+- Documentação de migração ampliada para cenários de worker/background com contexto curto por operação.
 
 ### Corrigido
 
 ### Removido
 
 ### Segurança
+
+### ⚠️ Depreciação (Controlada)
+
+- Deprecado o padrão de construtor de repository concreto que recebe simultaneamente `DbContext` e `IDbContextFactory<TContext>`.
+- O caminho legado permanece compatível nesta versão para transição gradual.
+- A remoção do padrão legado está planejada para major version futura.
+
+### 🧭 Guia de Migração
+
+- Em repository concreto, preferir construtor orientado a `IUnitOfWork<TContext>`.
+- Inicializar base com `unitOfWork.DbContext`.
+- Para contexto curto por operação, usar factory dedicada e aplicar auditoria (`UsernameContext`/`UserIdContext`) no contexto criado.
 
 ## [Sem versão registrada] - 2025-10-30
 

--- a/src/Nuuvify.CommonPack.UnitOfWork/Implementations/ShortLivedDbContextFactory.cs
+++ b/src/Nuuvify.CommonPack.UnitOfWork/Implementations/ShortLivedDbContextFactory.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Nuuvify.CommonPack.UnitOfWork.Abstraction.Interfaces;
+
+namespace Nuuvify.CommonPack.UnitOfWork;
+
+/// <summary>
+/// Creates short-lived db context instances using <see cref="IDbContextFactory{TContext}"/>.
+/// </summary>
+/// <typeparam name="TContext">The db context type.</typeparam>
+public sealed class ShortLivedDbContextFactory<TContext> : IShortLivedDbContextFactory<TContext>
+    where TContext : DbContext
+{
+    private readonly IDbContextFactory<TContext> _dbContextFactory;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ShortLivedDbContextFactory{TContext}"/>.
+    /// </summary>
+    /// <param name="dbContextFactory">Factory that creates short-lived db contexts.</param>
+    public ShortLivedDbContextFactory(IDbContextFactory<TContext> dbContextFactory)
+    {
+        _dbContextFactory = dbContextFactory ?? throw new ArgumentNullException(nameof(dbContextFactory));
+    }
+
+    /// <inheritdoc/>
+    public async Task<TContext> CreateAsync(
+        string usernameContext = null,
+        string userIdContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        if (!string.IsNullOrWhiteSpace(usernameContext) || !string.IsNullOrWhiteSpace(userIdContext))
+        {
+            dbContext.SetDbContextUsername(usernameContext, userIdContext);
+        }
+
+        return dbContext;
+    }
+}

--- a/src/Nuuvify.CommonPack.UnitOfWork/Implementations/UnitOfWorkFactory.cs
+++ b/src/Nuuvify.CommonPack.UnitOfWork/Implementations/UnitOfWorkFactory.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Nuuvify.CommonPack.UnitOfWork.Abstraction.Interfaces;
+
+namespace Nuuvify.CommonPack.UnitOfWork;
+
+/// <summary>
+/// Creates short-lived <see cref="IUnitOfWork{TContext}"/> instances using <see cref="IDbContextFactory{TContext}"/>.
+/// </summary>
+/// <typeparam name="TContext">The db context type.</typeparam>
+public sealed class UnitOfWorkFactory<TContext> : IUnitOfWorkFactory<TContext> where TContext : DbContext
+{
+    private readonly IDbContextFactory<TContext> _dbContextFactory;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="UnitOfWorkFactory{TContext}"/>.
+    /// </summary>
+    /// <param name="dbContextFactory">Factory that creates short-lived db contexts.</param>
+    public UnitOfWorkFactory(IDbContextFactory<TContext> dbContextFactory)
+    {
+        _dbContextFactory = dbContextFactory ?? throw new ArgumentNullException(nameof(dbContextFactory));
+    }
+
+    /// <inheritdoc/>
+    public async Task<IUnitOfWork<TContext>> CreateAsync(
+        string usernameContext = null,
+        string userIdContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var unitOfWork = new UnitOfWork<TContext>(dbContext)
+        {
+            UsernameContext = usernameContext,
+            UserIdContext = userIdContext
+        };
+
+        if (!string.IsNullOrWhiteSpace(usernameContext) || !string.IsNullOrWhiteSpace(userIdContext))
+        {
+            dbContext.SetDbContextUsername(usernameContext, userIdContext);
+        }
+
+        return unitOfWork;
+    }
+}

--- a/src/Nuuvify.CommonPack.UnitOfWork/Implementations/UnitOfWorkSetup.cs
+++ b/src/Nuuvify.CommonPack.UnitOfWork/Implementations/UnitOfWorkSetup.cs
@@ -30,6 +30,52 @@ public static class UnitOfWorkSetup
     }
 
     /// <summary>
+    /// Registers an opt-in factory that creates short-lived <see cref="IUnitOfWork{TContext}"/> instances.
+    /// </summary>
+    /// <typeparam name="TContext">The type of the db context.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <returns>The same service collection so that multiple calls can be chained.</returns>
+    /// <remarks>
+    /// This registration does not replace <see cref="AddUnitOfWork{TContext}(IServiceCollection)"/> behavior.
+    /// It adds an explicit opt-in path for short-lived units of work backed by <see cref="IDbContextFactory{TContext}"/>.
+    /// </remarks>
+    public static IServiceCollection AddUnitOfWorkFactory<TContext>(this IServiceCollection services)
+        where TContext : DbContext
+    {
+        _ = services.AddScoped<IUnitOfWorkFactory<TContext>, UnitOfWorkFactory<TContext>>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers an opt-in factory that creates short-lived <see cref="DbContext"/> instances.
+    /// </summary>
+    /// <typeparam name="TContext">The type of the db context.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <returns>The same service collection so that multiple calls can be chained.</returns>
+    public static IServiceCollection AddShortLivedDbContextFactory<TContext>(this IServiceCollection services)
+        where TContext : DbContext
+    {
+        _ = services.AddScoped<IShortLivedDbContextFactory<TContext>, ShortLivedDbContextFactory<TContext>>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers an opt-in factory that creates short-lived db context instances for worker/background flows.
+    /// </summary>
+    /// <typeparam name="TContext">The type of the db context.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <returns>The same service collection so that multiple calls can be chained.</returns>
+    public static IServiceCollection AddWorkerDbContextFactory<TContext>(this IServiceCollection services)
+        where TContext : DbContext
+    {
+        _ = services.AddScoped<IWorkerDbContextFactory<TContext>, WorkerDbContextFactory<TContext>>();
+
+        return services;
+    }
+
+    /// <summary>
     /// Registers the unit of work given context as a service in the <see cref="IServiceCollection"/>.
     /// </summary>
     /// <typeparam name="TContext1">The type of the db context.</typeparam>

--- a/src/Nuuvify.CommonPack.UnitOfWork/Implementations/WorkerDbContextFactory.cs
+++ b/src/Nuuvify.CommonPack.UnitOfWork/Implementations/WorkerDbContextFactory.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Nuuvify.CommonPack.UnitOfWork.Abstraction.Interfaces;
+
+namespace Nuuvify.CommonPack.UnitOfWork;
+
+/// <summary>
+/// Creates short-lived db context instances for worker/background flows.
+/// </summary>
+/// <typeparam name="TContext">The db context type.</typeparam>
+public class WorkerDbContextFactory<TContext> : IWorkerDbContextFactory<TContext>
+    where TContext : DbContext
+{
+    private readonly IDbContextFactory<TContext> _dbContextFactory;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="WorkerDbContextFactory{TContext}"/>.
+    /// </summary>
+    /// <param name="dbContextFactory">Factory that creates short-lived db contexts.</param>
+    public WorkerDbContextFactory(IDbContextFactory<TContext> dbContextFactory)
+    {
+        _dbContextFactory = dbContextFactory ?? throw new ArgumentNullException(nameof(dbContextFactory));
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<TContext> CreateAsync(
+        string usernameContext = null,
+        string userIdContext = null,
+        CancellationToken cancellationToken = default)
+    {
+        var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        if (!string.IsNullOrWhiteSpace(usernameContext) || !string.IsNullOrWhiteSpace(userIdContext))
+        {
+            dbContext.SetDbContextUsername(usernameContext, userIdContext);
+        }
+
+        return dbContext;
+    }
+}

--- a/src/Nuuvify.CommonPack.UnitOfWork/README.md
+++ b/src/Nuuvify.CommonPack.UnitOfWork/README.md
@@ -166,6 +166,15 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 // Registrar Unit of Work
 builder.Services.AddUnitOfWork<AppDbContext>();
 
+// Opcional: habilitar factory para UnitOfWork curto por operação
+builder.Services.AddUnitOfWorkFactory<AppDbContext>();
+
+// Opcional: habilitar factory para DbContext curto por operação
+builder.Services.AddShortLivedDbContextFactory<AppDbContext>();
+
+// Opcional: habilitar factory para cenários de worker/background
+builder.Services.AddWorkerDbContextFactory<AppDbContext>();
+
 // Ou com configurações customizadas
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork<AppDbContext>>();
 builder.Services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
@@ -180,6 +189,93 @@ using (var scope = app.Services.CreateScope())
 }
 
 app.Run();
+```
+
+### 2.1 UnitOfWork Curto com Factory (Opt-in)
+
+Quando o fluxo exige contexto EF curto por operação (ex.: worker/background processing), use a factory opt-in sem alterar o contrato atual de `IUnitOfWork<TContext>`.
+
+```csharp
+using Nuuvify.CommonPack.UnitOfWork.Abstraction.Interfaces;
+
+public sealed class WorkerProcessor
+{
+    private readonly IUnitOfWorkFactory<AppDbContext> _unitOfWorkFactory;
+
+    public WorkerProcessor(IUnitOfWorkFactory<AppDbContext> unitOfWorkFactory)
+    {
+        _unitOfWorkFactory = unitOfWorkFactory;
+    }
+
+    public async Task ProcessAsync(CancellationToken cancellationToken)
+    {
+        using var unitOfWork = await _unitOfWorkFactory.CreateAsync(
+            usernameContext: "worker-user",
+            userIdContext: "worker-id",
+            cancellationToken: cancellationToken);
+
+        var repository = new Repository<Product>(unitOfWork.DbContext, unitOfWork);
+        // ... operações no contexto curto
+        await unitOfWork.SaveChangesAsync(cancellationToken: cancellationToken);
+    }
+}
+```
+
+### 2.2 DbContext Curto com Factory Genérica (Opt-in)
+
+Quando o fluxo precisa apenas de um contexto EF curto por operação (sem `IUnitOfWork<TContext>`), use a factory genérica.
+
+```csharp
+using Nuuvify.CommonPack.UnitOfWork.Abstraction.Interfaces;
+
+public sealed class WorkerProcessor
+{
+    private readonly IShortLivedDbContextFactory<AppDbContext> _dbContextFactory;
+
+    public WorkerProcessor(IShortLivedDbContextFactory<AppDbContext> dbContextFactory)
+    {
+        _dbContextFactory = dbContextFactory;
+    }
+
+    public async Task ProcessAsync(CancellationToken cancellationToken)
+    {
+        await using var dbContext = await _dbContextFactory.CreateAsync(
+            usernameContext: "worker-user",
+            userIdContext: "worker-id",
+            cancellationToken: cancellationToken);
+
+        // ... operações no contexto curto
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}
+```
+
+### 2.3 Deprecação Controlada de Construtor de Repository
+
+- Está deprecado o padrão de construtor concreto que recebe ao mesmo tempo `DbContext` e `IDbContextFactory<TContext>`.
+- O padrão legado continua funcional nesta versão para garantir compatibilidade durante a migração.
+- A remoção definitiva do padrão legado está planejada para major version futura.
+
+#### Migração Recomendada
+
+1. Repository concreto deve receber `IUnitOfWork<TContext>` no construtor.
+2. A base deve ser inicializada com `unitOfWork.DbContext`.
+3. Para fluxo de worker/background com contexto curto por operação, criar factory dedicada para o provider/contexto.
+4. Aplicar auditoria (`UsernameContext` e `UserIdContext`) no contexto curto criado.
+
+```csharp
+public class PedidoRepository : BaseRepository<Pedido>, IPedidoRepository
+{
+    public PedidoRepository(
+        IUnitOfWork<AppDbContext> unitOfWork,
+        IUserAuthenticated userAuthenticated,
+        IMapper mapper,
+        IOptions<RequestConfiguration> requestConfiguration,
+        IDistributedCache cache)
+        : base(unitOfWork.DbContext, unitOfWork, userAuthenticated, mapper, requestConfiguration, cache)
+    {
+    }
+}
 ```
 
 ### 3. Configurar AutoHistory (Opcional)

--- a/test/Nuuvify.CommonPack.UnitOfWork.InMemory.xTest/Tests/DbContextExtensionsStaticStateCollection.cs
+++ b/test/Nuuvify.CommonPack.UnitOfWork.InMemory.xTest/Tests/DbContextExtensionsStaticStateCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace Nuuvify.CommonPack.UnitOfWork.InMemory.xTest.Tests;
+
+[CollectionDefinition("DbContextExtensionsStaticState", DisableParallelization = true)]
+public sealed class DbContextExtensionsStaticStateCollection
+{
+}

--- a/test/Nuuvify.CommonPack.UnitOfWork.InMemory.xTest/Tests/ShortLivedDbContextFactoryTest.cs
+++ b/test/Nuuvify.CommonPack.UnitOfWork.InMemory.xTest/Tests/ShortLivedDbContextFactoryTest.cs
@@ -7,6 +7,7 @@ using Xunit;
 namespace Nuuvify.CommonPack.UnitOfWork.InMemory.xTest.Tests;
 
 [Trait("Category", "Unit")]
+[Collection("DbContextExtensionsStaticState")]
 public sealed class ShortLivedDbContextFactoryTest
 {
     [Fact]

--- a/test/Nuuvify.CommonPack.UnitOfWork.InMemory.xTest/Tests/ShortLivedDbContextFactoryTest.cs
+++ b/test/Nuuvify.CommonPack.UnitOfWork.InMemory.xTest/Tests/ShortLivedDbContextFactoryTest.cs
@@ -1,0 +1,137 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Nuuvify.CommonPack.UnitOfWork.Abstraction.Interfaces;
+using Nuuvify.CommonPack.UnitOfWork.InMemory.xTest.Data;
+using Xunit;
+
+namespace Nuuvify.CommonPack.UnitOfWork.InMemory.xTest.Tests;
+
+[Trait("Category", "Unit")]
+public sealed class ShortLivedDbContextFactoryTest
+{
+    [Fact]
+    public async Task CreateAsync_ShouldCreateIndependentDbContexts()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"ShortLivedFactoryDb_{Guid.NewGuid()}")
+            .Options;
+        var dbContextFactory = new TrackingDbContextFactory(options);
+        IShortLivedDbContextFactory<AppDbContext> factory =
+            new ShortLivedDbContextFactory<AppDbContext>(dbContextFactory);
+
+        // Act
+        var first = await factory.CreateAsync("worker-a", "user-a");
+        var second = await factory.CreateAsync("worker-b", "user-b");
+
+        // Assert
+        Assert.NotSame(first, second);
+        Assert.Equal(2, dbContextFactory.CreatedCount);
+
+        first.Dispose();
+        second.Dispose();
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldApplyAuditContext()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"ShortLivedFactoryAuditDb_{Guid.NewGuid()}")
+            .Options;
+        var dbContextFactory = new TrackingDbContextFactory(options);
+        IShortLivedDbContextFactory<AppDbContext> factory =
+            new ShortLivedDbContextFactory<AppDbContext>(dbContextFactory);
+
+        // Act
+        var dbContext = await factory.CreateAsync("worker-audit", "user-audit");
+
+        // Assert
+        Assert.Equal("worker-audit", dbContext.GetDbContextUsername());
+        Assert.Equal("user-audit", dbContext.GetDbContextUserId());
+
+        dbContext.Dispose();
+    }
+
+    [Fact]
+    public void AddShortLivedDbContextFactory_ShouldRegisterOptInFactory()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        _ = services.AddDbContextFactory<AppDbContext>(options =>
+            options.UseInMemoryDatabase($"ShortLivedFactoryRegistrationDb_{Guid.NewGuid()}"));
+
+        // Act
+        _ = services.AddShortLivedDbContextFactory<AppDbContext>();
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var factory = scope.ServiceProvider.GetService<IShortLivedDbContextFactory<AppDbContext>>();
+
+        // Assert
+        Assert.NotNull(factory);
+    }
+
+    [Fact]
+    public async Task WorkerDbContextFactory_ShouldCreateDbContextWithAuditContext()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"WorkerFactoryAuditDb_{Guid.NewGuid()}")
+            .Options;
+        var dbContextFactory = new TrackingDbContextFactory(options);
+        IWorkerDbContextFactory<AppDbContext> factory =
+            new WorkerDbContextFactory<AppDbContext>(dbContextFactory);
+
+        // Act
+        var dbContext = await factory.CreateAsync("worker-audit", "worker-id");
+
+        // Assert
+        Assert.Equal("worker-audit", dbContext.GetDbContextUsername());
+        Assert.Equal("worker-id", dbContext.GetDbContextUserId());
+
+        dbContext.Dispose();
+    }
+
+    [Fact]
+    public void AddWorkerDbContextFactory_ShouldRegisterOptInFactory()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        _ = services.AddDbContextFactory<AppDbContext>(options =>
+            options.UseInMemoryDatabase($"WorkerFactoryRegistrationDb_{Guid.NewGuid()}"));
+
+        // Act
+        _ = services.AddWorkerDbContextFactory<AppDbContext>();
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var factory = scope.ServiceProvider.GetService<IWorkerDbContextFactory<AppDbContext>>();
+
+        // Assert
+        Assert.NotNull(factory);
+    }
+
+    private sealed class TrackingDbContextFactory : IDbContextFactory<AppDbContext>
+    {
+        private readonly DbContextOptions<AppDbContext> _options;
+        private readonly List<AppDbContext> _created = [];
+
+        public TrackingDbContextFactory(DbContextOptions<AppDbContext> options)
+        {
+            _options = options;
+        }
+
+        public int CreatedCount => _created.Count;
+
+        public AppDbContext CreateDbContext()
+        {
+            var context = new AppDbContext(_options);
+            _created.Add(context);
+            return context;
+        }
+
+        public Task<AppDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(CreateDbContext());
+        }
+    }
+}

--- a/test/Nuuvify.CommonPack.UnitOfWork.InMemory.xTest/Tests/UnitOfWorkFactoryTest.cs
+++ b/test/Nuuvify.CommonPack.UnitOfWork.InMemory.xTest/Tests/UnitOfWorkFactoryTest.cs
@@ -1,0 +1,105 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Nuuvify.CommonPack.UnitOfWork.Abstraction.Interfaces;
+using Nuuvify.CommonPack.UnitOfWork.InMemory.xTest.Data;
+using Nuuvify.CommonPack.UnitOfWork.InMemory.xTest.Entities;
+using Xunit;
+
+namespace Nuuvify.CommonPack.UnitOfWork.InMemory.xTest.Tests;
+
+[Trait("Category", "Unit")]
+public sealed class UnitOfWorkFactoryTest
+{
+    [Fact]
+    public async Task CreateAsync_ShouldCreateIndependentUnitsOfWork()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"FactoryDb_{Guid.NewGuid()}")
+            .Options;
+        var dbContextFactory = new TrackingDbContextFactory(options);
+        IUnitOfWorkFactory<AppDbContext> factory = new UnitOfWorkFactory<AppDbContext>(dbContextFactory);
+
+        // Act
+        var first = await factory.CreateAsync("worker-a", "user-a");
+        var second = await factory.CreateAsync("worker-b", "user-b");
+
+        // Assert
+        Assert.NotSame(first, second);
+        Assert.NotSame(first.DbContext, second.DbContext);
+        Assert.Equal(2, dbContextFactory.CreatedCount);
+        Assert.Equal("worker-a", first.UsernameContext);
+        Assert.Equal("user-a", first.UserIdContext);
+        Assert.Equal("worker-b", second.UsernameContext);
+        Assert.Equal("user-b", second.UserIdContext);
+
+        first.Dispose();
+        second.Dispose();
+    }
+
+    [Fact]
+    public async Task Dispose_ShouldDisposeCreatedDbContext()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"FactoryDisposeDb_{Guid.NewGuid()}")
+            .Options;
+        var dbContextFactory = new TrackingDbContextFactory(options);
+        IUnitOfWorkFactory<AppDbContext> factory = new UnitOfWorkFactory<AppDbContext>(dbContextFactory);
+        var unitOfWork = await factory.CreateAsync("worker-dispose", "user-dispose");
+
+        _ = await unitOfWork.DbContext.Set<Fatura>().CountAsync();
+
+        // Act
+        unitOfWork.Dispose();
+
+        // Assert
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+        {
+            _ = await unitOfWork.DbContext.Set<Fatura>().CountAsync();
+        });
+    }
+
+    [Fact]
+    public void AddUnitOfWorkFactory_ShouldRegisterOptInFactory()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        _ = services.AddDbContextFactory<AppDbContext>(options =>
+            options.UseInMemoryDatabase($"FactoryRegistrationDb_{Guid.NewGuid()}"));
+
+        // Act
+        _ = services.AddUnitOfWorkFactory<AppDbContext>();
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var factory = scope.ServiceProvider.GetService<IUnitOfWorkFactory<AppDbContext>>();
+
+        // Assert
+        Assert.NotNull(factory);
+    }
+
+    private sealed class TrackingDbContextFactory : IDbContextFactory<AppDbContext>
+    {
+        private readonly DbContextOptions<AppDbContext> _options;
+        private readonly List<AppDbContext> _created = [];
+
+        public TrackingDbContextFactory(DbContextOptions<AppDbContext> options)
+        {
+            _options = options;
+        }
+
+        public int CreatedCount => _created.Count;
+
+        public AppDbContext CreateDbContext()
+        {
+            var context = new AppDbContext(_options);
+            _created.Add(context);
+            return context;
+        }
+
+        public Task<AppDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(CreateDbContext());
+        }
+    }
+}

--- a/test/Nuuvify.CommonPack.UnitOfWork.InMemory.xTest/Tests/UnitOfWorkFactoryTest.cs
+++ b/test/Nuuvify.CommonPack.UnitOfWork.InMemory.xTest/Tests/UnitOfWorkFactoryTest.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace Nuuvify.CommonPack.UnitOfWork.InMemory.xTest.Tests;
 
 [Trait("Category", "Unit")]
+[Collection("DbContextExtensionsStaticState")]
 public sealed class UnitOfWorkFactoryTest
 {
     [Fact]


### PR DESCRIPTION
This pull request introduces opt-in support for creating short-lived `DbContext` and `UnitOfWork` instances, primarily aimed at scenarios like background processing and workers where an isolated context per operation is needed. It adds new factory interfaces and implementations, DI registration extensions, and updates documentation and changelogs to guide adoption and migration. The release also includes a controlled deprecation path for legacy repository constructors and reverts the package version to 2.4.0.

**New Factories and Interfaces for Short-Lived Contexts:**

- Added `IShortLivedDbContextFactory<TContext>`, `IWorkerDbContextFactory<TContext>`, and `IUnitOfWorkFactory<TContext>` interfaces for explicit creation of short-lived EF contexts and units of work, with optional audit context parameters. [[1]](diffhunk://#diff-bae59403ba042ea7304df3712e16256333fc8a126c9eee0ef38cef3cd5873c0eR1-R21) [[2]](diffhunk://#diff-f11ed180d853afd0107f67380e0335193eb985dbfb947c5aaca2e2c4d43b679eR1-R10) [[3]](diffhunk://#diff-b1dd0be0770895d74e31d76dc40e5b8c3f6e708d09854ea5e4bc9b458266317dR1-R20)
- Implemented `ShortLivedDbContextFactory<TContext>`, `WorkerDbContextFactory<TContext>`, and `UnitOfWorkFactory<TContext>` to provide these capabilities using `IDbContextFactory<TContext>`. [[1]](diffhunk://#diff-0d296302086440e6049762c8a7b6ec793803e9fda705de6e8422e8e2e39b27eeR1-R39) [[2]](diffhunk://#diff-219c64fc9ee44923ec4bd0a6773928774bb67e47c241e69e1e040f06fcca8b16R1-R39) [[3]](diffhunk://#diff-de21a7ee32770529cfacf72bacec5f9d78632e878c0766cf904cfb04df7305dbR1-R43)
- Added DI extension methods: `AddShortLivedDbContextFactory<TContext>()`, `AddWorkerDbContextFactory<TContext>()`, and `AddUnitOfWorkFactory<TContext>()` for easy registration.

**Documentation and Migration Guidance:**

- Expanded documentation in `README.md` with usage examples for the new factories, migration steps, and a controlled deprecation notice for repository constructors that accept both `DbContext` and `IDbContextFactory<TContext>`. [[1]](diffhunk://#diff-3b164eb5421142b76dbba87923bb9482b644f0de53a1233a651c9592d8241f1dR169-R177) [[2]](diffhunk://#diff-3b164eb5421142b76dbba87923bb9482b644f0de53a1233a651c9592d8241f1dR194-R280)
- Updated changelogs to describe new features, migration guidance, and deprecation plans. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13-R14) [[2]](diffhunk://#diff-6ce54ec7e0b68c7d7e17d14e2625c9e2c75fb97bd3c8f44373f691b101c403efR11-R12) [[3]](diffhunk://#diff-43736a40a2f2d5bb9482f965843bfd6aaee971c5da507f4907f70193e0e1c108R11-R35)

**Versioning:**

- Reverted package version from 2.5.0 to 2.4.0 in both `.cz.toml` and `Directory.Build.props` to align with release plans. [[1]](diffhunk://#diff-b6b307c6d5a59a69d1d3353add63a32ebe6d718c080f8d40cfc1676218ed480cL3-R3) [[2]](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907L16-R16)

**Testing Support:**

- Added a test collection definition to control parallelization for tests that depend on static state in `DbContextExtensions`.# Tipo de mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Testes
- [ ] Documentação
- [ ] Breaking change

# Resumo

Descreva objetivamente o problema e a solução proposta.

# Branch de destino

- [ ] `main` para release estável
- [ ] `qas` para preview
- [ ] `nugettest/qas` para build `dev`

# Checklist do autor

- [ ] Li o guia em `CONTRIBUTING.md`
- [ ] O código segue as convenções do projeto e o `.editorconfig`
- [ ] Executei build e os testes relevantes localmente
- [ ] Adicionei ou atualizei testes quando necessário
- [ ] Atualizei documentação e changelog quando necessário
- [ ] Avaliei impacto em compatibilidade, segurança e performance
- [ ] Escolhi a branch de destino correta para o tipo de release esperado

# Evidências

Inclua logs, prints, cobertura, benchmark ou qualquer evidência útil para a revisão.

# Issues relacionadas

Use `Closes #123` ou `Related #123`, quando aplicável.

# Checklist do revisor

- [ ] A alteração está clara, focada e justificada
- [ ] O impacto técnico foi avaliado
- [ ] Os testes cobrem os cenários relevantes
- [ ] A documentação está coerente com a mudança
- [ ] O alvo do PR está alinhado ao canal de release esperado
