### PR TITLE
feat: Bumped the project version in `Directory.Build.props` from `2.4.0` to `2.5.0`.

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,6 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2.4.0-preview.1"
+version = "2.5.0-preview.1"
 version_scheme = "semver2"
 bump_message = "chore(release): bump from $current_version to $new_version [skip ci]"
 annotated_tag = true

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
         <PackageProjectUrl>https://github.com/lzocateli/Nuuvify.CommonPack</PackageProjectUrl>
         <PackageIcon>logonuuvify.jpg</PackageIcon>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <Version>2.4.0</Version>
+        <Version>2.5.0</Version>
         <FileVersion>1520</FileVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>1701;1702;1705;1591</NoWarn>

--- a/test/Test-UnitExecute.ps1
+++ b/test/Test-UnitExecute.ps1
@@ -21,6 +21,9 @@
     Percentual mínimo de cobertura aceitável (padrão: 95)
 .PARAMETER Clean
     Se especificado, limpa o diretório de output antes da execução (padrão: $true)
+.PARAMETER OpenReport
+    Abre o relatório de cobertura no navegador ao final da execução.
+    Padrão: $true. Quando executado sem console interativo (CI, pipelines), o relatório não é aberto independentemente deste parâmetro.
 .PARAMETER RecreateTestResults
     Se especificado, remove e recria completamente a pasta TestResults do script (test-automation\TestResults)
     antes de qualquer outra operação. Use quando houver arquivos corrompidos ou travados.
@@ -57,6 +60,9 @@
 .EXAMPLE
     .\Test-UnitExecute.ps1 -RecreateTestResults
     Remove e recria completamente a pasta TestResults antes de executar os testes
+.EXAMPLE
+    .\Test-UnitExecute.ps1 -OpenReport:$false
+    Executa os testes sem abrir o relatório no navegador ao final
 #>
 
 [CmdletBinding()]
@@ -116,7 +122,10 @@ param (
     [bool]$Clean = $true,
 
     [Parameter(Position = 9)]
-    [switch]$RecreateTestResults
+    [switch]$RecreateTestResults,
+
+    [Parameter(Position = 10)]
+    [bool]$OpenReport = $true
 )
 
 # Verificar se --help foi passado como argumento
@@ -698,8 +707,8 @@ Write-Host ""
 # Abrir relatório no navegador
 $indexFile = Join-Path $reportPath "index.html"
 if (Test-Path $indexFile) {
-    $openReport = Read-Host "Deseja abrir o relatório no navegador? (S/N)"
-    if ($openReport -eq "S" -or $openReport -eq "s") {
+    $hasInteractiveConsole = [Environment]::UserInteractive -and -not [Console]::IsInputRedirected
+    if ($OpenReport -and $hasInteractiveConsole) {
         Start-Process $indexFile
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to the test automation script, allowing users to control whether the coverage report is automatically opened in the browser after test execution. It also updates the project and commitizen versions to 2.5.0.

**Test automation improvements:**

* Added a new `OpenReport` parameter to `Test-UnitExecute.ps1` that controls whether the coverage report is opened in the browser after tests complete. This defaults to `$true`, but will not open the report in non-interactive environments (e.g., CI pipelines). Documentation and usage examples were updated accordingly. [[1]](diffhunk://#diff-c67d7712cbe4e9cbdbb612985d45429f0928e01ee8141955aeaa00ef98a0452cR24-R26) [[2]](diffhunk://#diff-c67d7712cbe4e9cbdbb612985d45429f0928e01ee8141955aeaa00ef98a0452cR63-R65) [[3]](diffhunk://#diff-c67d7712cbe4e9cbdbb612985d45429f0928e01ee8141955aeaa00ef98a0452cL119-R128) [[4]](diffhunk://#diff-c67d7712cbe4e9cbdbb612985d45429f0928e01ee8141955aeaa00ef98a0452cL701-R711)

**Version updates:**

* Bumped the project version in `Directory.Build.props` from `2.4.0` to `2.5.0`.
* Updated the commitizen configuration in `.cz.toml` to use version `2.5.0-preview.1`.# Tipo de mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Testes
- [ ] Documentação
- [ ] Breaking change

# Resumo

Descreva objetivamente o problema e a solução proposta.

# Branch de destino

- [ ] `main` para release estável
- [ ] `qas` para preview
- [ ] `nugettest/qas` para build `dev`

# Checklist do autor

- [ ] Li o guia em `CONTRIBUTING.md`
- [ ] O código segue as convenções do projeto e o `.editorconfig`
- [ ] Executei build e os testes relevantes localmente
- [ ] Adicionei ou atualizei testes quando necessário
- [ ] Atualizei documentação e changelog quando necessário
- [ ] Avaliei impacto em compatibilidade, segurança e performance
- [ ] Escolhi a branch de destino correta para o tipo de release esperado

# Evidências

Inclua logs, prints, cobertura, benchmark ou qualquer evidência útil para a revisão.

# Issues relacionadas

Use `Closes #123` ou `Related #123`, quando aplicável.

# Checklist do revisor

- [ ] A alteração está clara, focada e justificada
- [ ] O impacto técnico foi avaliado
- [ ] Os testes cobrem os cenários relevantes
- [ ] A documentação está coerente com a mudança
- [ ] O alvo do PR está alinhado ao canal de release esperado
