### PR TITLE
fix: bump version to 2.5.1 and improve TokenService e StandardHttpClient

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,6 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2.5.0-preview.1"
+version = "2.5.1-preview.1"
 version_scheme = "semver2"
 bump_message = "chore(release): bump from $current_version to $new_version [skip ci]"
 annotated_tag = true

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
         <PackageProjectUrl>https://github.com/lzocateli/Nuuvify.CommonPack</PackageProjectUrl>
         <PackageIcon>logonuuvify.jpg</PackageIcon>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <Version>2.5.0</Version>
+        <Version>2.5.1</Version>
         <FileVersion>1520</FileVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>1701;1702;1705;1591</NoWarn>

--- a/src/Nuuvify.CommonPack.StandardHttpClient/Extensions/DictionaryExtensions.cs
+++ b/src/Nuuvify.CommonPack.StandardHttpClient/Extensions/DictionaryExtensions.cs
@@ -5,9 +5,6 @@ namespace System.Collections.Generic;
 
 public static class CustomDictionaryExtensions
 {
-
-    private static StringBuilder _query;
-
     /// <summary>
     /// QueryString não pode exceder 128 caracteres
     /// </summary>
@@ -15,24 +12,25 @@ public static class CustomDictionaryExtensions
     /// <returns></returns>
     public static string ToQueryString(this IDictionary<string, string> dic)
     {
-        _query = new StringBuilder();
-        if (_query.Capacity > 128)
+        var query = new StringBuilder(capacity: 128);
+
+        if (query.Capacity > 128)
         {
-            _query.Capacity = 128;
+            query.Capacity = 128;
         }
 
-        if (_query.Length == 0 || _query[0] != '?')
+        if (query.Length == 0 || query[0] != '?')
         {
-            _ = _query.Insert(0, '?');
+            _ = query.Insert(0, '?');
         }
 
         for (int i = 0; i < dic.Count; i++)
         {
-            _ = _query.Append(CultureInfo.InvariantCulture, $"{dic.ElementAtOrDefault(i).Key}={dic.ElementAtOrDefault(i).Value}&");
+            _ = query.Append(CultureInfo.InvariantCulture, $"{dic.ElementAtOrDefault(i).Key}={dic.ElementAtOrDefault(i).Value}&");
 
         }
 
-        return QueryString(_query.ToString());
+        return QueryString(query.ToString());
 
     }
 

--- a/src/Nuuvify.CommonPack.StandardHttpClient/Implementation/BaseStandardHttpClient.cs
+++ b/src/Nuuvify.CommonPack.StandardHttpClient/Implementation/BaseStandardHttpClient.cs
@@ -159,6 +159,18 @@ public abstract partial class BaseStandardHttpClient
         string api,
         int jsonDataDepth = 1) where T : class
     {
+        if (standardReturn is null)
+        {
+            AddNotification(new NotificationR(
+                property: "BaseStandardHttpClient.ReturnClass",
+                message: $"Retorno HTTP nulo para a classe {typeof(T).Name}-Correlation: {_standardHttpClient.CorrelationId}",
+                aggregatorId: api,
+                type: ApplicationErrorType,
+                originNotification: null));
+
+            return (T)Convert.ChangeType(null, typeof(T), CultureInfo.InvariantCulture);
+        }
+
         if (standardReturn.Success)
         {
             var messageClean = standardReturn.GetReturnMessageWithoutRn();
@@ -226,6 +238,18 @@ public abstract partial class BaseStandardHttpClient
         string api,
         int jsonDataDepth = 1) where T : class
     {
+
+        if (standardReturn is null)
+        {
+            AddNotification(new NotificationR(
+                property: "BaseStandardHttpClient.ReturnList",
+                message: $"Retorno HTTP nulo para a classe {typeof(T).Name}-Correlation: {_standardHttpClient.CorrelationId}",
+                aggregatorId: api,
+                type: ApplicationErrorType,
+                originNotification: null));
+
+            return new List<T>();
+        }
 
         if (standardReturn.Success)
         {

--- a/src/Nuuvify.CommonPack.StandardHttpClient/Polly/TokenService.cs
+++ b/src/Nuuvify.CommonPack.StandardHttpClient/Polly/TokenService.cs
@@ -1,5 +1,8 @@
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
@@ -47,6 +50,11 @@ public class TokenService : ITokenService
 
     private string GetHttpClientTokenName { get; set; }
 
+    private static string Origin([CallerMemberName] string method = "")
+    {
+        return $"{nameof(TokenService)}.{method}";
+    }
+
     public string HttpClientTokenName(string httpClientName = "CredentialApi")
     {
         GetHttpClientTokenName = string.IsNullOrWhiteSpace(httpClientName)
@@ -74,53 +82,97 @@ public class TokenService : ITokenService
         string userClaim = null,
         CancellationToken cancellationToken = default)
     {
-        var messageLog = $"{nameof(TokenService.GetNewToken)}";
+        var messageLog = Origin();
 
-        var messageBody = new
+        try
         {
-            Login = login,
-            Password = password
-        };
+            var messageBody = new
+            {
+                Login = login,
+                Password = password
+            };
 
-        var userName = _accessor?.HttpContext?.User.GetLogin();
-        userClaim ??= userName;
+            var userName = _accessor?.HttpContext?.User.GetLogin();
+            userClaim ??= userName;
 
-        _standardHttpClient.CreateClient(GetHttpClientTokenName ?? HttpClientTokenName());
-        _standardHttpClient.ResetStandardHttpClient();
+            _standardHttpClient.CreateClient(GetHttpClientTokenName ?? HttpClientTokenName());
+            _standardHttpClient.ResetStandardHttpClient();
 
-        if (!string.IsNullOrWhiteSpace(userClaim))
-            _ = _standardHttpClient.WithHeader(Constants.UserClaimHeader, userClaim);
+            if (!string.IsNullOrWhiteSpace(userClaim))
+                _ = _standardHttpClient.WithHeader(Constants.UserClaimHeader, userClaim);
 
-        _logger.LogDebug("{MessageLog} - User Claim: {UserClaim}", messageLog, userClaim);
+            _logger.LogDebug("{MessageLog} - User Claim: {UserClaim}", messageLog, userClaim);
 
-        var response = await _standardHttpClient.Post(
-            urlRoute: urlToken,
-            messageBody: messageBody,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
+            var response = await _standardHttpClient.Post(
+                urlRoute: urlToken,
+                messageBody: messageBody,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        _credentialToken = ReturnClass<CredentialToken>(response);
+            _credentialToken = ReturnClass<CredentialToken>(response);
 
-        if (_credentialToken is null || string.IsNullOrWhiteSpace(_credentialToken.Token))
+            if (_credentialToken is null || string.IsNullOrWhiteSpace(_credentialToken.Token))
+            {
+                _credentialToken = new CredentialToken();
+                _credentialToken.Warnings["ResponseMessage"] = response?.ReturnMessage ?? "Token nao retornado pela API de credenciais.";
+
+                _notifications.Add(new NotificationR(Origin(), _credentialToken.Warnings["ResponseMessage"]));
+                _logger.LogWarning("{MessageLog} - Response message invalid: {ReturnCode} {ReturnMessage}", messageLog, response?.ReturnCode, response?.ReturnMessage);
+
+                return false;
+            }
+
+            var tempToken = _credentialToken.Token;
+            var tempCreated = _credentialToken.Created;
+            var tempExpire = _credentialToken.Expires;
+
+            _credentialToken.LoginId ??= login;
+            _credentialToken.Password = password;
+            _credentialToken.Expires = tempExpire;
+            _credentialToken.Created = tempCreated;
+            _credentialToken.Token = tempToken;
+
+            return true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            _credentialToken = new CredentialToken();
-            _credentialToken.Warnings.Add("ResponseMessage", response.ReturnMessage);
-
-            _logger.LogWarning("{MessageLog} - Response message invalid: {ReturnCode} {ReturnMessage}", messageLog, response?.ReturnCode, response?.ReturnMessage);
-
+            throw;
+        }
+        catch (TaskCanceledException ex)
+        {
+            _notifications.Add(new NotificationR(Origin(), $"Timeout ao obter token na API de credenciais: {ex.Message}"));
+            _logger.LogError(ex, "{MessageLog} - Timeout ao obter token.", messageLog);
             return false;
         }
-
-        var tempToken = _credentialToken.Token;
-        var tempCreated = _credentialToken.Created;
-        var tempExpire = _credentialToken.Expires;
-
-        _credentialToken.LoginId ??= login;
-        _credentialToken.Password = password;
-        _credentialToken.Expires = tempExpire;
-        _credentialToken.Created = tempCreated;
-        _credentialToken.Token = tempToken;
-
-        return true;
+        catch (TimeoutException ex)
+        {
+            _notifications.Add(new NotificationR(Origin(), $"Timeout ao obter token na API de credenciais: {ex.Message}"));
+            _logger.LogError(ex, "{MessageLog} - Timeout ao obter token.", messageLog);
+            return false;
+        }
+        catch (HttpRequestException ex)
+        {
+            _notifications.Add(new NotificationR(Origin(), $"Falha HTTP ao obter token: {ex.Message}"));
+            _logger.LogError(ex, "{MessageLog} - Falha HTTP ao obter token.", messageLog);
+            return false;
+        }
+        catch (SocketException ex)
+        {
+            _notifications.Add(new NotificationR(Origin(), $"Falha de rede ao obter token: {ex.Message}"));
+            _logger.LogError(ex, "{MessageLog} - Falha de rede ao obter token.", messageLog);
+            return false;
+        }
+        catch (AuthenticationException ex)
+        {
+            _notifications.Add(new NotificationR(Origin(), $"Falha de autenticacao TLS ao obter token: {ex.Message}"));
+            _logger.LogError(ex, "{MessageLog} - Falha de autenticacao TLS ao obter token.", messageLog);
+            return false;
+        }
+        catch (JsonException ex)
+        {
+            _notifications.Add(new NotificationR(Origin(), $"Falha ao processar resposta de token: {ex.Message}"));
+            _logger.LogError(ex, "{MessageLog} - Falha ao processar resposta de token.", messageLog);
+            return false;
+        }
     }
 
     ///<inheritdoc/>
@@ -130,10 +182,9 @@ public class TokenService : ITokenService
         string userClaim = null,
         CancellationToken cancellationToken = default)
     {
-
         _notifications.Clear();
 
-        var messageLog = $"{nameof(TokenService.GetToken)}";
+        var messageLog = Origin();
         _logger.LogDebug("{MessageLog} - Inicio", messageLog);
 
         if (string.IsNullOrWhiteSpace(login))
@@ -157,14 +208,29 @@ public class TokenService : ITokenService
             string.IsNullOrWhiteSpace(urlLogin) ||
             string.IsNullOrWhiteSpace(urlToken))
         {
-            _notifications.Add(new NotificationR(nameof(GetToken), "Algum dos dados a seguir não deveria estar branco: login ou password ou urlLogin ou urlToken"));
+            _notifications.Add(new NotificationR(Origin(), "Algum dos dados a seguir não deveria estar branco: login ou password ou urlLogin ou urlToken"));
 
             _logger.LogWarning("{MessageLog} - Algum dos dados a seguir não deveria estar branco: login ou password ou urlLogin ou urlToken", messageLog);
 
             return null;
         }
 
-        _ = await GetNewToken(urlToken, login, password, userClaim, cancellationToken).ConfigureAwait(false);
+        var tokenGenerated = await GetNewToken(urlToken, login, password, userClaim, cancellationToken).ConfigureAwait(false);
+
+        if (!tokenGenerated)
+        {
+            var warningMessage = _credentialToken?.Warnings.TryGetValue("ResponseMessage", out var responseMessage) == true
+                ? responseMessage
+                : "Falha ao obter token na API de credenciais.";
+
+            if (_notifications.All(n => !string.Equals(n.Property, Origin(), StringComparison.Ordinal)))
+            {
+                _notifications.Add(new NotificationR(Origin(), warningMessage));
+            }
+
+            _logger.LogWarning("{MessageLog} - Falha ao obter token: {WarningMessage}", messageLog, warningMessage);
+            return null;
+        }
 
         if (_credentialToken != null && !string.IsNullOrWhiteSpace(_credentialToken.Token))
         {
@@ -208,12 +274,17 @@ public class TokenService : ITokenService
             token = item?.Replace("bearer", "").Replace("Bearer", "").Trim();
         }
 
-        if (_accessor?.HttpContext == null) return false;
-        return _accessor.HttpContext.User.Identity.IsAuthenticated;
+        return _accessor?.HttpContext?.User?.Identity?.IsAuthenticated == true;
     }
 
     private T ReturnClass<T>(HttpStandardReturn returnResult) where T : class
     {
+        if (returnResult == null)
+        {
+            _notifications.Add(new NotificationR(Origin(), "Retorno HTTP nulo ao obter token."));
+            return (T)Convert.ChangeType(null, typeof(T), CultureInfo.InvariantCulture);
+        }
+
         _notifications.Clear();
 
         if (returnResult.Success)


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the `Nuuvify.CommonPack.StandardHttpClient` package, focusing on more robust error handling, improved notification and logging, and some minor version updates. The most significant changes are enhanced error handling in the `TokenService` class, better null checking in HTTP client return methods, and a minor update to the package version.

**Error handling and robustness improvements:**

* Enhanced error handling in `TokenService`: Added comprehensive try/catch blocks in `GetNewToken` to handle timeouts, HTTP/network/TLS errors, and JSON parsing issues, with detailed notifications and logging for each case. Also improved notification messages and ensured all relevant exceptions are captured. [[1]](diffhunk://#diff-c7c21dc9fed83345f0275904ea51be680646437fa18f7eeec3a8377bee011c09L77-R88) [[2]](diffhunk://#diff-c7c21dc9fed83345f0275904ea51be680646437fa18f7eeec3a8377bee011c09L106-R118) [[3]](diffhunk://#diff-c7c21dc9fed83345f0275904ea51be680646437fa18f7eeec3a8377bee011c09R136-R176) [[4]](diffhunk://#diff-c7c21dc9fed83345f0275904ea51be680646437fa18f7eeec3a8377bee011c09L133-R187) [[5]](diffhunk://#diff-c7c21dc9fed83345f0275904ea51be680646437fa18f7eeec3a8377bee011c09L160-R233)
* Improved null checking in HTTP client return methods: Updated `ReturnClass<T>` and `ReturnList<T>` in `BaseStandardHttpClient` to handle null HTTP responses gracefully by adding notifications and returning default values, preventing potential null reference exceptions. [[1]](diffhunk://#diff-27642ca973e9489b82327625d7687bb0a814cfa472f448814e127a60bcf3cbbaR162-R173) [[2]](diffhunk://#diff-27642ca973e9489b82327625d7687bb0a814cfa472f448814e127a60bcf3cbbaR242-R253)
* Improved null handling in `TokenService.ReturnClass<T>`: Now adds a notification and safely returns null if the HTTP result is null.

**Code quality and maintainability:**

* Refactored `DictionaryExtensions.ToQueryString`: Removed unnecessary static field, improved string builder initialization, and ensured more robust query string construction.
* Added `Origin` helper method in `TokenService` to standardize log and notification source formatting.

**Versioning and metadata:**

* Bumped package version from `2.5.0` to `2.5.1` in both `.cz.toml` and `Directory.Build.props` to reflect the new changes and improvements. [[1]](diffhunk://#diff-b6b307c6d5a59a69d1d3353add63a32ebe6d718c080f8d40cfc1676218ed480cL3-R3) [[2]](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907L16-R16)# Tipo de mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Testes
- [ ] Documentação
- [ ] Breaking change

# Resumo

Descreva objetivamente o problema e a solução proposta.

# Branch de destino

- [ ] `main` para release estável
- [ ] `qas` para preview
- [ ] `nugettest/qas` para build `dev`

# Checklist do autor

- [ ] Li o guia em `CONTRIBUTING.md`
- [ ] O código segue as convenções do projeto e o `.editorconfig`
- [ ] Executei build e os testes relevantes localmente
- [ ] Adicionei ou atualizei testes quando necessário
- [ ] Atualizei documentação e changelog quando necessário
- [ ] Avaliei impacto em compatibilidade, segurança e performance
- [ ] Escolhi a branch de destino correta para o tipo de release esperado

# Evidências

Inclua logs, prints, cobertura, benchmark ou qualquer evidência útil para a revisão.

# Issues relacionadas

Use `Closes #123` ou `Related #123`, quando aplicável.

# Checklist do revisor

- [ ] A alteração está clara, focada e justificada
- [ ] O impacto técnico foi avaliado
- [ ] Os testes cobrem os cenários relevantes
- [ ] A documentação está coerente com a mudança
- [ ] O alvo do PR está alinhado ao canal de release esperado
