### PR TITLE
fix: TokenService.GetToken

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,6 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2.5.1-preview.1"
+version = "2.5.2-preview.1"
 version_scheme = "semver2"
 bump_message = "chore(release): bump from $current_version to $new_version [skip ci]"
 annotated_tag = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/spec
 ### Corrigido
 - Tratamento de exceções em `ReceiveAndDelete` ajustado para evitar falhas secundárias ao processar mensagens já removidas da fila.
 - Validação do CNPJ reforçada para rejeitar entradas inválidas (formato, tamanho e repetição total de caracteres).
+- `TokenService.GetToken` no pacote `Nuuvify.CommonPack.StandardHttpClient` agora resolve `ClientId`/`ClientSecret` também a partir de chaves planas com separador `--` (ex.: `AzureAdOpenID--cc--ClientId`), cobrindo cenários em que segredos do Key Vault são carregados via `AddKeyPerFile` sem tradução de `--` para `:`. Isso corrige falha de obtenção de token em workers/produção.
 
 ### Removido
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
         <PackageProjectUrl>https://github.com/lzocateli/Nuuvify.CommonPack</PackageProjectUrl>
         <PackageIcon>logonuuvify.jpg</PackageIcon>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <Version>2.5.1</Version>
+        <Version>2.5.2</Version>
         <FileVersion>1520</FileVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>1701;1702;1705;1591</NoWarn>

--- a/src/Nuuvify.CommonPack.StandardHttpClient/CHANGELOG.md
+++ b/src/Nuuvify.CommonPack.StandardHttpClient/CHANGELOG.md
@@ -12,6 +12,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/spec
 ### Alterado
 
 ### Corrigido
+- `TokenService.GetToken` agora resolve `ClientId`/`ClientSecret` também a partir de chaves planas com separador `--` (ex.: `AzureAdOpenID--cc--ClientId` e `AzureAdOpenID--cc--ClientSecret`), além das chaves hierárquicas `:` e de `ApisCredentials`. Cobre cenários em que segredos do Azure Key Vault chegam à configuração sem tradução de `--` para `:` (ex.: `AddKeyPerFile`/secrets montados), corrigindo falha de obtenção de token em workers e produção.
 
 ### Removido
 

--- a/src/Nuuvify.CommonPack.StandardHttpClient/Polly/TokenService.cs
+++ b/src/Nuuvify.CommonPack.StandardHttpClient/Polly/TokenService.cs
@@ -191,11 +191,13 @@ public class TokenService : ITokenService
         {
             login = _configuration.GetSection("ApisCredentials:Username")?.Value;
             login ??= _configuration.GetSection("AzureAdOpenID:cc:ClientId")?.Value;
+            login ??= _configuration.GetSection("AzureAdOpenID--cc--ClientId")?.Value;
         }
         if (string.IsNullOrWhiteSpace(password))
         {
             password = _configuration.GetSection("ApisCredentials:Password")?.Value;
             password ??= _configuration.GetSection("AzureAdOpenID:cc:ClientSecret")?.Value;
+            password ??= _configuration.GetSection("AzureAdOpenID--cc--ClientSecret")?.Value;
         }
 
         var urlLogin = _configuration.GetSection("AppConfig:AppURLs:UrlLoginApi")?.Value;

--- a/test/Nuuvify.CommonPack.StandardHttpClient.xTest/TokenServiceConfigurationTests.cs
+++ b/test/Nuuvify.CommonPack.StandardHttpClient.xTest/TokenServiceConfigurationTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Nuuvify.CommonPack.StandardHttpClient.Results;
+
+namespace Nuuvify.CommonPack.StandardHttpClient.xTest;
+
+[Trait("Category", "Unit")]
+public class TokenServiceConfigurationTests
+{
+    private const string GuardMessageFragment = "não deveria estar branco";
+    private const string UrlLoginApi = "https://login/";
+    private const string UrlLoginApiTokenPath = "connect/token";
+    private const string ExpectedTokenUrl = UrlLoginApi + UrlLoginApiTokenPath;
+
+    private static void SetupSection(Mock<IConfiguration> configuration, string key, string value)
+    {
+        var section = new Mock<IConfigurationSection>();
+        _ = section.Setup(s => s.Value).Returns(value);
+        _ = configuration.Setup(c => c.GetSection(key)).Returns(section.Object);
+    }
+
+    private static TokenService CreateTokenService(
+        Mock<IConfiguration> configuration,
+        Mock<IStandardHttpClient> httpClient)
+    {
+        var options = new Mock<IOptions<CredentialToken>>();
+        _ = options.Setup(o => o.Value).Returns(new CredentialToken());
+
+        var accessor = new Mock<IHttpContextAccessor>();
+
+        return new TokenService(
+            options.Object,
+            httpClient.Object,
+            configuration.Object,
+            NullLogger<TokenService>.Instance,
+            accessor.Object);
+    }
+
+    [Fact]
+    public async Task GetToken_ComChavesDuploHifen_DeveResolverCredenciaisEChamarApi()
+    {
+        var configuration = new Mock<IConfiguration>();
+        SetupSection(configuration, "AzureAdOpenID--cc--ClientId", "client-id-literal");
+        SetupSection(configuration, "AzureAdOpenID--cc--ClientSecret", "client-secret-literal");
+        SetupSection(configuration, "AppConfig:AppURLs:UrlLoginApi", UrlLoginApi);
+        SetupSection(configuration, "AppConfig:AppURLs:UrlLoginApiToken", UrlLoginApiTokenPath);
+
+        var httpClient = new Mock<IStandardHttpClient>();
+        _ = httpClient.Setup(x => x.WithHeader(It.IsAny<string>(), It.IsAny<object>()))
+            .Returns(httpClient.Object);
+        _ = httpClient.Setup(x => x.Post(
+                It.IsAny<string>(),
+                It.IsAny<object>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HttpStandardReturn
+            {
+                Success = false,
+                ReturnCode = "500",
+                ReturnMessage = "indisponivel"
+            });
+
+        var service = CreateTokenService(configuration, httpClient);
+
+        _ = await service.GetToken();
+
+        httpClient.Verify(x => x.Post(
+            It.Is<string>(url => url == ExpectedTokenUrl),
+            It.IsAny<object>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        Assert.DoesNotContain(
+            service.Notifications,
+            n => n.Message.Contains(GuardMessageFragment, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetToken_SemNenhumaCredencial_DeveRetornarNullSemChamarApi()
+    {
+        var configuration = new Mock<IConfiguration>();
+        SetupSection(configuration, "AppConfig:AppURLs:UrlLoginApi", UrlLoginApi);
+        SetupSection(configuration, "AppConfig:AppURLs:UrlLoginApiToken", UrlLoginApiTokenPath);
+
+        var httpClient = new Mock<IStandardHttpClient>();
+
+        var service = CreateTokenService(configuration, httpClient);
+
+        var result = await service.GetToken();
+
+        Assert.Null(result);
+        httpClient.Verify(x => x.Post(
+            It.IsAny<string>(),
+            It.IsAny<object>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        Assert.Contains(
+            service.Notifications,
+            n => n.Message.Contains(GuardMessageFragment, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetToken_ComChavesColonEDuploHifen_DevePriorizarChaveColon()
+    {
+        var configuration = new Mock<IConfiguration>();
+        SetupSection(configuration, "AzureAdOpenID:cc:ClientId", "client-id-colon");
+        SetupSection(configuration, "AzureAdOpenID:cc:ClientSecret", "client-secret-colon");
+        SetupSection(configuration, "AzureAdOpenID--cc--ClientId", "client-id-literal");
+        SetupSection(configuration, "AzureAdOpenID--cc--ClientSecret", "client-secret-literal");
+        SetupSection(configuration, "AppConfig:AppURLs:UrlLoginApi", UrlLoginApi);
+        SetupSection(configuration, "AppConfig:AppURLs:UrlLoginApiToken", UrlLoginApiTokenPath);
+
+        object capturedBody = null;
+        var httpClient = new Mock<IStandardHttpClient>();
+        _ = httpClient.Setup(x => x.WithHeader(It.IsAny<string>(), It.IsAny<object>()))
+            .Returns(httpClient.Object);
+        _ = httpClient.Setup(x => x.Post(
+                It.IsAny<string>(),
+                It.IsAny<object>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, object, CancellationToken>((_, body, _) => capturedBody = body)
+            .ReturnsAsync(new HttpStandardReturn
+            {
+                Success = false,
+                ReturnCode = "500",
+                ReturnMessage = "indisponivel"
+            });
+
+        var service = CreateTokenService(configuration, httpClient);
+
+        _ = await service.GetToken();
+
+        Assert.NotNull(capturedBody);
+        var loginProperty = capturedBody.GetType().GetProperty("Login");
+        Assert.NotNull(loginProperty);
+        Assert.Equal("client-id-colon", loginProperty.GetValue(capturedBody));
+    }
+}


### PR DESCRIPTION
This pull request improves the handling of credential configuration for the `TokenService.GetToken` method, ensuring it works correctly in scenarios where configuration keys from Azure Key Vault are loaded with double-hyphen (`--`) separators instead of colons (`:`). This fixes token retrieval issues in production and worker environments. Additionally, new unit tests have been added to verify the updated credential resolution logic. The package version is also bumped to reflect these changes.

**Credential resolution improvements:**

* Updated `TokenService.GetToken` to resolve `ClientId` and `ClientSecret` from both colon-separated (`:`) and double-hyphen (`--`) keys (e.g., `AzureAdOpenID--cc--ClientId`), covering scenarios where secrets are loaded via `AddKeyPerFile` without key translation. This ensures token acquisition works reliably in all environments.

**Testing enhancements:**

* Added `TokenServiceConfigurationTests` unit tests to verify that `GetToken` correctly resolves credentials from both key formats, prioritizes colon-separated keys, and behaves as expected when credentials are missing.

**Documentation and changelog updates:**

* Updated `CHANGELOG.md` and `src/Nuuvify.CommonPack.StandardHttpClient/CHANGELOG.md` to document the improved credential resolution and the fix for token retrieval failures. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24) [[2]](diffhunk://#diff-20f50ec81f2caa14e7b96a404250aac8f16a530ab6079ccf7dbc4de561b95a38R15)

**Version bump:**

* Increased package version to `2.5.2` in `Directory.Build.props` and `.cz.toml` to reflect these changes. [[1]](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907L16-R16) [[2]](diffhunk://#diff-b6b307c6d5a59a69d1d3353add63a32ebe6d718c080f8d40cfc1676218ed480cL3-R3)# Tipo de mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Testes
- [ ] Documentação
- [ ] Breaking change

# Resumo

Descreva objetivamente o problema e a solução proposta.

# Branch de destino

- [ ] `main` para release estável
- [ ] `qas` para preview
- [ ] `nugettest/qas` para build `dev`

# Checklist do autor

- [ ] Li o guia em `CONTRIBUTING.md`
- [ ] O código segue as convenções do projeto e o `.editorconfig`
- [ ] Executei build e os testes relevantes localmente
- [ ] Adicionei ou atualizei testes quando necessário
- [ ] Atualizei documentação e changelog quando necessário
- [ ] Avaliei impacto em compatibilidade, segurança e performance
- [ ] Escolhi a branch de destino correta para o tipo de release esperado

# Evidências

Inclua logs, prints, cobertura, benchmark ou qualquer evidência útil para a revisão.

# Issues relacionadas

Use `Closes #123` ou `Related #123`, quando aplicável.

# Checklist do revisor

- [ ] A alteração está clara, focada e justificada
- [ ] O impacto técnico foi avaliado
- [ ] Os testes cobrem os cenários relevantes
- [ ] A documentação está coerente com a mudança
- [ ] O alvo do PR está alinhado ao canal de release esperado
