### PR TITLE
refactor: enhance nullability handling and error management in SFTP

### DIFF
--- a/src/Nuuvify.CommonPack.Extensions/Logging/NuuvifyLogFormatter.cs
+++ b/src/Nuuvify.CommonPack.Extensions/Logging/NuuvifyLogFormatter.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
@@ -15,8 +17,8 @@ namespace Nuuvify.CommonPack.Logging;
 public class NuuvifyLogFormatter : ConsoleFormatter, IDisposable
 {
 
-    private readonly IDisposable _formatterOptionsReloadToken;
-    private readonly IDisposable _colorOptionsReloadToken;
+    private readonly IDisposable? _formatterOptionsReloadToken;
+    private readonly IDisposable? _colorOptionsReloadToken;
     private NuuvifyLogFormatterOptions _nuuvifyLogOptions;
     private NuuvifyLogColorConfiguration _nuuvifyLogColorConfiguration;
 
@@ -41,18 +43,18 @@ public class NuuvifyLogFormatter : ConsoleFormatter, IDisposable
         }
 
         _formatterOptionsReloadToken = nuuvifyLogOptions.OnChange(ReloadLoggerOptions);
-        _nuuvifyLogOptions = nuuvifyLogOptions.CurrentValue;
+        _nuuvifyLogOptions = nuuvifyLogOptions.CurrentValue ?? new NuuvifyLogFormatterOptions();
 
         _colorOptionsReloadToken = nuuvifyLogColorConfiguration.OnChange(ReloadLoggerColorConfiguration);
-        _nuuvifyLogColorConfiguration = nuuvifyLogColorConfiguration.CurrentValue;
+        _nuuvifyLogColorConfiguration = nuuvifyLogColorConfiguration.CurrentValue ?? new NuuvifyLogColorConfiguration();
 
     }
 
     private void ReloadLoggerOptions(NuuvifyLogFormatterOptions options) =>
-        _nuuvifyLogOptions = options;
+        _nuuvifyLogOptions = options ?? new NuuvifyLogFormatterOptions();
 
     private void ReloadLoggerColorConfiguration(NuuvifyLogColorConfiguration config) =>
-        _nuuvifyLogColorConfiguration = config;
+        _nuuvifyLogColorConfiguration = config ?? new NuuvifyLogColorConfiguration();
 
     /// <summary>
     /// Escreve uma entrada de log formatada com o prefixo e as cores configuradas.
@@ -61,18 +63,18 @@ public class NuuvifyLogFormatter : ConsoleFormatter, IDisposable
     /// <param name="logLevel">Nível do log.</param>
     /// <param name="eventId">Identificador do evento.</param>
     /// <param name="state">Estado associado à entrada de log.</param>
-    /// <param name="exception">Exceção opcional associada ao log.</param>
+    /// <param name="exception">Exceção opcional associada ao log. Pode ser <see langword="null"/>.</param>
     /// <param name="message">Mensagem já formatada a ser escrita.</param>
-    /// <param name="scopeProvider">Provider de escopo ativo.</param>
+    /// <param name="scopeProvider">Provider de escopo ativo. Pode ser <see langword="null"/>.</param>
     /// <param name="textWriter">Destino do texto formatado.</param>
     /// <param name="name">Categoria ou nome do logger.</param>
     public virtual void Write<TState>(
         LogLevel logLevel,
         EventId eventId,
         TState state,
-        Exception exception,
+        Exception? exception,
         string message,
-        IExternalScopeProvider scopeProvider,
+        IExternalScopeProvider? scopeProvider,
         TextWriter textWriter,
         string name)
     {
@@ -100,7 +102,7 @@ public class NuuvifyLogFormatter : ConsoleFormatter, IDisposable
     /// <inheritdoc />
     public override void Write<TState>(in
         LogEntry<TState> logEntry,
-        IExternalScopeProvider scopeProvider,
+        IExternalScopeProvider? scopeProvider,
         TextWriter textWriter)
     {
 

--- a/src/Nuuvify.CommonPack.MftMailbox.Sftp/SftpMftMailboxClient.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox.Sftp/SftpMftMailboxClient.cs
@@ -483,11 +483,23 @@ public sealed class SftpMftMailboxClient : IProtocolMftClient
     private SftpClientScope CreateClientScope()
     {
         var connectionInfo = BuildConnectionInfo();
-        var client = new SftpClient(connectionInfo.ConnectionInfo);
+        try
+        {
+            var client = new SftpClient(connectionInfo.ConnectionInfo);
 
-        ConfigureHostKeyValidation(client);
+            ConfigureHostKeyValidation(client);
 
-        return new SftpClientScope(client, connectionInfo.OwnedDisposables);
+            return new SftpClientScope(client, connectionInfo.OwnedDisposables);
+        }
+        catch
+        {
+            foreach (var disposable in connectionInfo.OwnedDisposables)
+            {
+                disposable.Dispose();
+            }
+
+            throw;
+        }
     }
 
     private ConnectionInfoContext BuildConnectionInfo()
@@ -498,22 +510,47 @@ public sealed class SftpMftMailboxClient : IProtocolMftClient
                 ? new PrivateKeyFile(_options.PrivateKeyPath)
                 : new PrivateKeyFile(_options.PrivateKeyPath, _options.PrivateKeyPassphrase);
 
-            var authenticationMethod = new PrivateKeyAuthenticationMethod(_options.Username, keyFile);
-            var connectionInfo = new ConnectionInfo(_options.Host, _options.Port, _options.Username, authenticationMethod);
+            try
+            {
+                var authenticationMethod = new PrivateKeyAuthenticationMethod(_options.Username, keyFile);
 
-            return new ConnectionInfoContext(
-                connectionInfo,
-                keyFile,
-                authenticationMethod);
+                try
+                {
+                    var connectionInfo = new ConnectionInfo(_options.Host, _options.Port, _options.Username, authenticationMethod);
+
+                    return new ConnectionInfoContext(
+                        connectionInfo,
+                        keyFile,
+                        authenticationMethod);
+                }
+                catch
+                {
+                    authenticationMethod.Dispose();
+                    throw;
+                }
+            }
+            catch
+            {
+                keyFile.Dispose();
+                throw;
+            }
         }
 
         if (!string.IsNullOrWhiteSpace(_options.Password))
         {
             var passwordConnectionInfo = new PasswordConnectionInfo(_options.Host, _options.Port, _options.Username, _options.Password);
 
-            return new ConnectionInfoContext(
-                passwordConnectionInfo,
-                passwordConnectionInfo);
+            try
+            {
+                return new ConnectionInfoContext(
+                    passwordConnectionInfo,
+                    passwordConnectionInfo);
+            }
+            catch
+            {
+                passwordConnectionInfo.Dispose();
+                throw;
+            }
         }
 
         throw new InvalidOperationException("SFTP credentials are not configured. Configure Password or PrivateKeyPath.");

--- a/src/Nuuvify.CommonPack.MftMailbox/Protocols/IProtocolMftClient.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox/Protocols/IProtocolMftClient.cs
@@ -4,13 +4,13 @@ using Nuuvify.CommonPack.MftMailbox.Abstraction.Models;
 namespace Nuuvify.CommonPack.MftMailbox.Protocols;
 
 /// <summary>
-/// Interface interna que combina todos os contratos operacionais MFT em um único ponto de implementação.
+/// Contrato público de infraestrutura que combina os contratos operacionais MFT em um único ponto de implementação.
 /// </summary>
 /// <remarks>
 /// Implementada pelos clientes concretos (<c>SftpMftMailboxClient</c> e <c>HttpMftMailboxClient</c>).
 /// Registrado no container DI como <c>IProtocolMftClient</c> (singleton) e resolvido pela
 /// <c>MftClientFactory</c> por meio de <see cref="Protocol"/>.
-/// Consumidores externos não devem depender diretamente desta interface; use os contratos
+/// Embora público para suportar registro/resolução entre pacotes, consumidores externos não devem depender diretamente desta interface; use os contratos
 /// individuais (<see cref="IMftTransferClient"/>, <see cref="IMftInboundClient"/>, etc.)
 /// obtidos via <see cref="IMftClientFactory"/>.
 /// </remarks>

--- a/test/Nuuvify.CommonPack.MftMailbox.xTest/Services/HttpMftMailboxClientInboundTests.cs
+++ b/test/Nuuvify.CommonPack.MftMailbox.xTest/Services/HttpMftMailboxClientInboundTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Linq;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Nuuvify.CommonPack.MftMailbox.Abstraction.Models;
@@ -19,39 +20,43 @@ public sealed class HttpMftMailboxClientInboundTests
     [Fact]
     public async Task ReceiveBatchAsync_ComEnvelopeItens_NaoDeveChamarListagemRemota()
     {
-        using var handler = new StubHttpMessageHandler(request =>
-        {
-            if (request.RequestUri?.AbsolutePath == "/mailbox/list")
-            {
-                throw new InvalidOperationException("List endpoint should not be called when envelope has explicit items.");
-            }
+        var responses = new List<HttpResponseMessage>();
 
-            if (request.RequestUri?.AbsolutePath == "/mailbox/download")
+        try
+        {
+            using var handler = new StubHttpMessageHandler(request =>
             {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                if (request.RequestUri?.AbsolutePath == "/mailbox/list")
                 {
-                    Content = new ByteArrayContent(new byte[] { 1, 2, 3 })
-                });
-            }
+                    throw new InvalidOperationException("List endpoint should not be called when envelope has explicit items.");
+                }
 
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
-        });
+                if (request.RequestUri?.AbsolutePath == "/mailbox/download")
+                {
+                    return Task.FromResult(RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ByteArrayContent(new byte[] { 1, 2, 3 })
+                    }));
+                }
 
-        using var httpClient = new HttpClient(handler, disposeHandler: false);
+                return Task.FromResult(RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.NotFound)));
+            });
 
-        var client = CreateClient(httpClient, new HttpMftMailboxOptions
-        {
-            BaseUrl = "http://localhost",
-            DownloadPath = "/mailbox/download",
-            ListPath = "/mailbox/list"
-        });
+            using var httpClient = new HttpClient(handler, disposeHandler: false);
 
-        var envelope = new TransferEnvelope
-        {
-            IntegrationKey = "mainframe-x",
-            CorrelationId = Guid.NewGuid().ToString("N"),
-            Protocol = MftProtocol.Https,
-            Items =
+            var client = CreateClient(httpClient, new HttpMftMailboxOptions
+            {
+                BaseUrl = "http://localhost",
+                DownloadPath = "/mailbox/download",
+                ListPath = "/mailbox/list"
+            });
+
+            var envelope = new TransferEnvelope
+            {
+                IntegrationKey = "mainframe-x",
+                CorrelationId = Guid.NewGuid().ToString("N"),
+                Protocol = MftProtocol.Https,
+                Items =
             {
                 new TransferItem
                 {
@@ -60,23 +65,33 @@ public sealed class HttpMftMailboxClientInboundTests
                     RemotePath = "/inbound/arquivo-c.dat"
                 }
             }
-        };
+            };
 
-        var result = await client.ReceiveBatchAsync(envelope);
+            var result = await client.ReceiveBatchAsync(envelope);
 
-        Assert.Single(result);
-        Assert.Equal("item-001", result.First().ItemId);
-        Assert.Equal("arquivo-c.dat", result.First().FileName);
+            Assert.Single(result);
+            Assert.Equal("item-001", result.First().ItemId);
+            Assert.Equal("arquivo-c.dat", result.First().FileName);
 
-        foreach (var item in result)
+            foreach (var item in result)
+            {
+                await item.DisposeAsync();
+            }
+        }
+        finally
         {
-            await item.DisposeAsync();
+            foreach (var response in responses)
+            {
+                response.Dispose();
+            }
         }
     }
 
     [Fact]
     public async Task ReceiveBatchAsync_ListaRemota_DeveRespeitarOrdenacaoPorNome()
     {
+        var responses = new List<HttpResponseMessage>();
+
         var payload = new
         {
             items = new[]
@@ -86,53 +101,69 @@ public sealed class HttpMftMailboxClientInboundTests
             }
         };
 
-        using var handler = new StubHttpMessageHandler(request =>
+        try
         {
-            if (request.RequestUri?.AbsolutePath == "/mailbox/list")
+            using var handler = new StubHttpMessageHandler(request =>
             {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                if (request.RequestUri?.AbsolutePath == "/mailbox/list")
                 {
-                    Content = JsonContent.Create(payload)
-                });
-            }
+                    return Task.FromResult(RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = JsonContent.Create(payload)
+                    }));
+                }
 
-            if (request.RequestUri?.AbsolutePath == "/mailbox/download")
+                if (request.RequestUri?.AbsolutePath == "/mailbox/download")
+                {
+                    return Task.FromResult(RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ByteArrayContent(DownloadPayload)
+                    }));
+                }
+
+                return Task.FromResult(RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.NotFound)));
+            });
+
+            using var httpClient = new HttpClient(handler, disposeHandler: false);
+
+            var client = CreateClient(httpClient, new HttpMftMailboxOptions
             {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new ByteArrayContent(DownloadPayload)
-                });
+                BaseUrl = "http://localhost",
+                DownloadPath = "/mailbox/download",
+                ListPath = "/mailbox/list",
+                InboundFileOrdering = InboundFileOrdering.FileNameAscending
+            });
+
+            var envelope = new TransferEnvelope
+            {
+                IntegrationKey = "mainframe-x",
+                CorrelationId = Guid.NewGuid().ToString("N"),
+                Protocol = MftProtocol.Https
+            };
+
+            var result = await client.ReceiveBatchAsync(envelope);
+            var orderedNames = result.Select(x => x.FileName).ToArray();
+
+            Assert.Equal(new[] { "A-file.txt", "B-file.txt" }, orderedNames);
+
+            foreach (var item in result)
+            {
+                await item.DisposeAsync();
             }
-
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
-        });
-
-        using var httpClient = new HttpClient(handler, disposeHandler: false);
-
-        var client = CreateClient(httpClient, new HttpMftMailboxOptions
-        {
-            BaseUrl = "http://localhost",
-            DownloadPath = "/mailbox/download",
-            ListPath = "/mailbox/list",
-            InboundFileOrdering = InboundFileOrdering.FileNameAscending
-        });
-
-        var envelope = new TransferEnvelope
-        {
-            IntegrationKey = "mainframe-x",
-            CorrelationId = Guid.NewGuid().ToString("N"),
-            Protocol = MftProtocol.Https
-        };
-
-        var result = await client.ReceiveBatchAsync(envelope);
-        var orderedNames = result.Select(x => x.FileName).ToArray();
-
-        Assert.Equal(new[] { "A-file.txt", "B-file.txt" }, orderedNames);
-
-        foreach (var item in result)
-        {
-            await item.DisposeAsync();
         }
+        finally
+        {
+            foreach (var response in responses)
+            {
+                response.Dispose();
+            }
+        }
+    }
+
+    private static HttpResponseMessage RegisterResponse(ICollection<HttpResponseMessage> responses, HttpResponseMessage response)
+    {
+        responses.Add(response);
+        return response;
     }
 
     private static HttpMftMailboxClient CreateClient(HttpClient httpClient, HttpMftMailboxOptions httpOptions)

--- a/test/Nuuvify.CommonPack.MftMailbox.xTest/Services/HttpMftMailboxClientUploadMetadataTests.cs
+++ b/test/Nuuvify.CommonPack.MftMailbox.xTest/Services/HttpMftMailboxClientUploadMetadataTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Nuuvify.CommonPack.MftMailbox.Abstraction.Models;
@@ -16,83 +17,105 @@ public sealed class HttpMftMailboxClientUploadMetadataTests
     [Fact]
     public async Task SendSingleAsync_DeveIncluirMetadadosComPrefixosConfiguradosNoMultipart()
     {
+        var responses = new List<HttpResponseMessage>();
         string? multipartBody = null;
+        using var uploadContentStream = new MemoryStream(new byte[] { 1, 2, 3 });
 
-        using var handler = new StubHttpMessageHandler(async request =>
+        try
         {
-            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/mailbox/upload")
+            using var handler = new StubHttpMessageHandler(async request =>
             {
-                multipartBody = await request.Content!.ReadAsStringAsync();
-                return new HttpResponseMessage(HttpStatusCode.OK);
-            }
-
-            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/mailbox/status")
-            {
-                return new HttpResponseMessage(HttpStatusCode.OK)
+                if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/mailbox/upload")
                 {
-                    Content = JsonContent.Create(new TransferStatus
-                    {
-                        IntegrationKey = "erp-http",
-                        ItemId = "item-001",
-                        State = TransferState.Succeeded
-                    })
-                };
-            }
-
-            return new HttpResponseMessage(HttpStatusCode.NotFound);
-        });
-
-        using var httpClient = new HttpClient(handler, disposeHandler: false);
-        var client = new HttpMftMailboxClient(
-            httpClient,
-            Options.Create(new HttpMftMailboxOptions
-            {
-                BaseUrl = "http://localhost",
-                UploadPath = "/mailbox/upload",
-                StatusPath = "/mailbox/status",
-                IncludeMetadataInUploadForm = true,
-                EnvelopeMetadataFieldPrefix = "env-",
-                ItemMetadataFieldPrefix = "item-"
-            }),
-            Options.Create(new MftMailboxOptions()),
-            new InMemoryMftIdempotencyStore(),
-            new NullTransferAuditSink(),
-            NullLogger<HttpMftMailboxClient>.Instance);
-
-        var result = await client.SendSingleAsync(new TransferEnvelope
-        {
-            IntegrationKey = "erp-http",
-            CorrelationId = Guid.NewGuid().ToString("N"),
-            Protocol = MftProtocol.Https,
-            Metadata = new Dictionary<string, string>
-            {
-                ["source"] = "sap",
-                ["batch"] = "42"
-            },
-            Items =
-            {
-                new TransferItem
-                {
-                    ItemId = "item-001",
-                    FileName = "orders.csv",
-                    Metadata = new Dictionary<string, string>
-                    {
-                        ["priority"] = "high"
-                    },
-                    ContentFactory = _ => Task.FromResult<Stream>(new MemoryStream(new byte[] { 1, 2, 3 }))
+                    multipartBody = await request.Content!.ReadAsStringAsync();
+                    return RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.OK));
                 }
-            }
-        });
 
-        Assert.Equal(TransferState.Succeeded, result.State);
-        Assert.NotNull(multipartBody);
-        Assert.Contains("orders.csv", multipartBody, StringComparison.Ordinal);
-        Assert.Contains("env-", multipartBody, StringComparison.Ordinal);
-        Assert.Contains("sap", multipartBody, StringComparison.Ordinal);
-        Assert.Contains("env-", multipartBody, StringComparison.Ordinal);
-        Assert.Contains("42", multipartBody, StringComparison.Ordinal);
-        Assert.Contains("item-", multipartBody, StringComparison.Ordinal);
-        Assert.Contains("high", multipartBody, StringComparison.Ordinal);
+                if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/mailbox/status")
+                {
+                    return RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = JsonContent.Create(new TransferStatus
+                        {
+                            IntegrationKey = "erp-http",
+                            ItemId = "item-001",
+                            State = TransferState.Succeeded
+                        })
+                    });
+                }
+
+                return RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.NotFound));
+            });
+
+            using var httpClient = new HttpClient(handler, disposeHandler: false);
+            var client = new HttpMftMailboxClient(
+                httpClient,
+                Options.Create(new HttpMftMailboxOptions
+                {
+                    BaseUrl = "http://localhost",
+                    UploadPath = "/mailbox/upload",
+                    StatusPath = "/mailbox/status",
+                    IncludeMetadataInUploadForm = true,
+                    EnvelopeMetadataFieldPrefix = "env-",
+                    ItemMetadataFieldPrefix = "item-"
+                }),
+                Options.Create(new MftMailboxOptions()),
+                new InMemoryMftIdempotencyStore(),
+                new NullTransferAuditSink(),
+                NullLogger<HttpMftMailboxClient>.Instance);
+
+            var result = await client.SendSingleAsync(new TransferEnvelope
+            {
+                IntegrationKey = "erp-http",
+                CorrelationId = Guid.NewGuid().ToString("N"),
+                Protocol = MftProtocol.Https,
+                Metadata = new Dictionary<string, string>
+                {
+                    ["source"] = "sap",
+                    ["batch"] = "42"
+                },
+                Items =
+                {
+                    new TransferItem
+                    {
+                        ItemId = "item-001",
+                        FileName = "orders.csv",
+                        Metadata = new Dictionary<string, string>
+                        {
+                            ["priority"] = "high"
+                        },
+                        ContentFactory = _ =>
+                        {
+                            uploadContentStream.Position = 0;
+                            return Task.FromResult<Stream>(uploadContentStream);
+                        }
+                    }
+                }
+            });
+
+            Assert.Equal(TransferState.Succeeded, result.State);
+            Assert.NotNull(multipartBody);
+            Assert.Contains("orders.csv", multipartBody, StringComparison.Ordinal);
+            Assert.Contains("env-", multipartBody, StringComparison.Ordinal);
+            Assert.Contains("sap", multipartBody, StringComparison.Ordinal);
+            Assert.Contains("env-", multipartBody, StringComparison.Ordinal);
+            Assert.Contains("42", multipartBody, StringComparison.Ordinal);
+            Assert.Contains("item-", multipartBody, StringComparison.Ordinal);
+            Assert.Contains("high", multipartBody, StringComparison.Ordinal);
+        }
+        finally
+        {
+            foreach (var response in responses)
+            {
+                response.Dispose();
+            }
+        }
+    }
+
+    private static HttpResponseMessage RegisterResponse(ICollection<HttpResponseMessage> responses, HttpResponseMessage response)
+    {
+        responses.Add(response);
+        return response;
     }
 
     private sealed class StubHttpMessageHandler : HttpMessageHandler


### PR DESCRIPTION
This pull request introduces several improvements focused on resource management, nullability safety, and code documentation. The main changes include enhanced disposal of HTTP responses in tests to prevent resource leaks, improved nullability annotations and handling in the logging formatter, safer disposal patterns in SFTP connection setup, and clearer documentation in public interfaces.

**Resource management improvements:**

* All HTTP-based tests in `HttpMftMailboxClientInboundTests.cs` and `HttpMftMailboxClientUploadMetadataTests.cs` now track and dispose of all `HttpResponseMessage` objects created during test execution, preventing resource leaks. Helper methods were added to centralize this logic. [[1]](diffhunk://#diff-62fc0a0767f08e8c5600b81e51f64fa74344bf7ca5cd52c0725faec4b549c8a9R22-R25) [[2]](diffhunk://#diff-62fc0a0767f08e8c5600b81e51f64fa74344bf7ca5cd52c0725faec4b549c8a9L31-R42) [[3]](diffhunk://#diff-62fc0a0767f08e8c5600b81e51f64fa74344bf7ca5cd52c0725faec4b549c8a9R81-R94) [[4]](diffhunk://#diff-62fc0a0767f08e8c5600b81e51f64fa74344bf7ca5cd52c0725faec4b549c8a9R104-R124) [[5]](diffhunk://#diff-62fc0a0767f08e8c5600b81e51f64fa74344bf7ca5cd52c0725faec4b549c8a9R154-R167) [[6]](diffhunk://#diff-343df78112487d4f74239b142e32bababdbd2f90898dc6bc793afe18fdeb60a2R20-R47) [[7]](diffhunk://#diff-343df78112487d4f74239b142e32bababdbd2f90898dc6bc793afe18fdeb60a2L82-R91) [[8]](diffhunk://#diff-343df78112487d4f74239b142e32bababdbd2f90898dc6bc793afe18fdeb60a2R106-R119)

* The SFTP client (`SftpMftMailboxClient.cs`) now ensures all disposable resources are released if an exception occurs during connection or authentication setup, using nested `try/catch` blocks and explicit disposal. [[1]](diffhunk://#diff-ecfeb6ce0f6c31118a2df1afa3ead8678b8525a75c5300a77d04358e3d0c6f3eR486-R503) [[2]](diffhunk://#diff-ecfeb6ce0f6c31118a2df1afa3ead8678b8525a75c5300a77d04358e3d0c6f3eR513-R554)

**Nullability and API safety:**

* The logging formatter (`NuuvifyLogFormatter.cs`) is now annotated with nullable reference types (`#nullable enable`). Internal fields and method parameters are updated to use nullable types where appropriate, and default values are provided to avoid null reference exceptions. [[1]](diffhunk://#diff-5075d3ddcf7e146f3dae02a964d2487f3c91b0db0b260a0521e2d7029b4683aaR1-R2) [[2]](diffhunk://#diff-5075d3ddcf7e146f3dae02a964d2487f3c91b0db0b260a0521e2d7029b4683aaL18-R21) [[3]](diffhunk://#diff-5075d3ddcf7e146f3dae02a964d2487f3c91b0db0b260a0521e2d7029b4683aaL44-R57) [[4]](diffhunk://#diff-5075d3ddcf7e146f3dae02a964d2487f3c91b0db0b260a0521e2d7029b4683aaL64-R77) [[5]](diffhunk://#diff-5075d3ddcf7e146f3dae02a964d2487f3c91b0db0b260a0521e2d7029b4683aaL103-R105)

**Documentation and code clarity:**

* The summary documentation for the `IProtocolMftClient` interface was updated to clarify its intended usage and visibility, emphasizing its role as a public infrastructure contract and correct usage patterns for consumers.

These changes collectively improve the reliability, maintainability, and clarity of both the production and test code.…lient and logging formatter

# Tipo de mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Testes
- [ ] Documentação
- [ ] Breaking change

# Resumo

Descreva objetivamente o problema e a solução proposta.

# Branch de destino

- [ ] `main` para release estável
- [ ] `qas` para preview
- [ ] `nugettest/qas` para build `dev`

# Checklist do autor

- [ ] Li o guia em `CONTRIBUTING.md`
- [ ] O código segue as convenções do projeto e o `.editorconfig`
- [ ] Executei build e os testes relevantes localmente
- [ ] Adicionei ou atualizei testes quando necessário
- [ ] Atualizei documentação e changelog quando necessário
- [ ] Avaliei impacto em compatibilidade, segurança e performance
- [ ] Escolhi a branch de destino correta para o tipo de release esperado

# Evidências

Inclua logs, prints, cobertura, benchmark ou qualquer evidência útil para a revisão.

# Issues relacionadas

Use `Closes #123` ou `Related #123`, quando aplicável.

# Checklist do revisor

- [ ] A alteração está clara, focada e justificada
- [ ] O impacto técnico foi avaliado
- [ ] Os testes cobrem os cenários relevantes
- [ ] A documentação está coerente com a mudança
- [ ] O alvo do PR está alinhado ao canal de release esperado
