### PR TITLE
refactor: remove nullable enablement from project files and enhance i…

### DIFF
--- a/src/Nuuvify.CommonPack.Extensions/Logging/NuuvifyLogSetupExtensions.cs
+++ b/src/Nuuvify.CommonPack.Extensions/Logging/NuuvifyLogSetupExtensions.cs
@@ -97,4 +97,36 @@ public static class NuuvifyLogSetupExtensions
         return builder;
     }
 
+    /// <summary>
+    /// Mantém compatibilidade com versões anteriores que registravam o formatter via AddNuuvifyConsoleFormatter.
+    /// </summary>
+    /// <param name="builder">Builder de logging que receberá o formatter.</param>
+    /// <param name="configureFormatter">Ação para customizar as opções do formatter.</param>
+    /// <param name="configureColor">Ação opcional para customizar o mapeamento de cores por nível de log.</param>
+    /// <returns>O mesmo <see cref="ILoggingBuilder"/> para encadeamento.</returns>
+    public static ILoggingBuilder AddNuuvifyConsoleFormatter(
+        this ILoggingBuilder builder,
+        Action<NuuvifyLogFormatterOptions> configureFormatter,
+        Action<NuuvifyLogColorConfiguration> configureColor = default)
+    {
+        return builder.AddCustomFormatter(configureFormatter, configureColor);
+    }
+
+    /// <summary>
+    /// Mantém compatibilidade com versões anteriores que registravam o formatter via AddNuuvifyConsoleFormatter.
+    /// </summary>
+    /// <param name="builder">Builder de logging que receberá o formatter.</param>
+    /// <param name="configureFormatter">Ação para customizar as opções do formatter.</param>
+    /// <param name="configureConsole">Ação opcional para customizar o provider de console padrão do .NET.</param>
+    /// <param name="configureColor">Ação opcional para customizar o mapeamento de cores por nível de log.</param>
+    /// <returns>O mesmo <see cref="ILoggingBuilder"/> para encadeamento.</returns>
+    public static ILoggingBuilder AddNuuvifyConsoleFormatter(
+        this ILoggingBuilder builder,
+        Action<NuuvifyLogFormatterOptions> configureFormatter,
+        Action<ConsoleLoggerOptions> configureConsole,
+        Action<NuuvifyLogColorConfiguration> configureColor = default)
+    {
+        return builder.AddCustomFormatter(configureFormatter, configureConsole, configureColor);
+    }
+
 }

--- a/src/Nuuvify.CommonPack.MftMailbox.Abstraction/Nuuvify.CommonPack.MftMailbox.Abstraction.csproj
+++ b/src/Nuuvify.CommonPack.MftMailbox.Abstraction/Nuuvify.CommonPack.MftMailbox.Abstraction.csproj
@@ -3,7 +3,6 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
         <PackageId>Nuuvify.CommonPack.MftMailbox.Abstraction</PackageId>
         <Title>Nuuvify CommonPack MFT Mailbox Abstraction</Title>
         <PackageTags>Nuuvify;MFT;Mailbox;SFTP;HTTPS;Abstraction;.NET</PackageTags>

--- a/src/Nuuvify.CommonPack.MftMailbox.Http/Nuuvify.CommonPack.MftMailbox.Http.csproj
+++ b/src/Nuuvify.CommonPack.MftMailbox.Http/Nuuvify.CommonPack.MftMailbox.Http.csproj
@@ -1,27 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <PackageId>Nuuvify.CommonPack.MftMailbox.Http</PackageId>
-    <Title>Nuuvify CommonPack MFT Mailbox HTTP Adapter</Title>
-    <PackageTags>Nuuvify;MFT;Mailbox;HTTP;HTTPS;Streaming;.NET</PackageTags>
-    <Description>Adapter HTTPS Mailbox para envio, recebimento, status e ACK/NACK.</Description>
-    <Product>Nuuvify CommonPack MFT Mailbox HTTP Adapter</Product>
-    <RootNamespace>Nuuvify.CommonPack.MftMailbox.Http</RootNamespace>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <PackageId>Nuuvify.CommonPack.MftMailbox.Http</PackageId>
+        <Title>Nuuvify CommonPack MFT Mailbox HTTP Adapter</Title>
+        <PackageTags>Nuuvify;MFT;Mailbox;HTTP;HTTPS;Streaming;.NET</PackageTags>
+        <Description>Adapter HTTPS Mailbox para envio, recebimento, status e ACK/NACK.</Description>
+        <Product>Nuuvify CommonPack MFT Mailbox HTTP Adapter</Product>
+        <RootNamespace>Nuuvify.CommonPack.MftMailbox.Http</RootNamespace>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Options" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Nuuvify.CommonPack.MftMailbox\Nuuvify.CommonPack.MftMailbox.csproj" />
-    <ProjectReference Include="..\Nuuvify.CommonPack.MftMailbox.Abstraction\Nuuvify.CommonPack.MftMailbox.Abstraction.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Nuuvify.CommonPack.MftMailbox\Nuuvify.CommonPack.MftMailbox.csproj" />
+        <ProjectReference Include="..\Nuuvify.CommonPack.MftMailbox.Abstraction\Nuuvify.CommonPack.MftMailbox.Abstraction.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/src/Nuuvify.CommonPack.MftMailbox.Redis/Nuuvify.CommonPack.MftMailbox.Redis.csproj
+++ b/src/Nuuvify.CommonPack.MftMailbox.Redis/Nuuvify.CommonPack.MftMailbox.Redis.csproj
@@ -3,7 +3,6 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
         <NoWarn>$(NoWarn);NU1603</NoWarn>
         <PackageId>Nuuvify.CommonPack.MftMailbox.Redis</PackageId>
         <Title>Nuuvify CommonPack MFT Mailbox — Redis Integration</Title>

--- a/src/Nuuvify.CommonPack.MftMailbox/Nuuvify.CommonPack.MftMailbox.csproj
+++ b/src/Nuuvify.CommonPack.MftMailbox/Nuuvify.CommonPack.MftMailbox.csproj
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <PackageId>Nuuvify.CommonPack.MftMailbox</PackageId>
     <Title>Nuuvify CommonPack MFT Mailbox</Title>
     <PackageTags>Nuuvify;MFT;Mailbox;Factory;Idempotency;Audit;.NET</PackageTags>

--- a/src/Nuuvify.CommonPack.MftMailbox/Services/InMemoryMftIdempotencyStore.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox/Services/InMemoryMftIdempotencyStore.cs
@@ -25,9 +25,15 @@ public sealed class InMemoryMftIdempotencyStore : IMftIdempotencyStore
     /// <see langword="true"/> se a chave foi inserida pela primeira vez (processamento pode prosseguir);
     /// <see langword="false"/> se já existia (item já processado ou em andamento).
     /// </returns>
+    /// <exception cref="ArgumentException">Lançado quando <paramref name="idempotencyKey"/> é nula, vazia ou whitespace.</exception>
     public Task<bool> TryStartAsync(string idempotencyKey, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            throw new ArgumentException("Chave de idempotência não pode ser nula ou vazia.", nameof(idempotencyKey));
+        }
 
         var started = _state.TryAdd(idempotencyKey, "started");
         return Task.FromResult(started);
@@ -38,9 +44,15 @@ public sealed class InMemoryMftIdempotencyStore : IMftIdempotencyStore
     /// </summary>
     /// <param name="idempotencyKey">Chave composta da transferência.</param>
     /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <exception cref="ArgumentException">Lançado quando <paramref name="idempotencyKey"/> é nula, vazia ou whitespace.</exception>
     public Task MarkCompletedAsync(string idempotencyKey, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            throw new ArgumentException("Chave de idempotência não pode ser nula ou vazia.", nameof(idempotencyKey));
+        }
 
         _state[idempotencyKey] = "completed";
         return Task.CompletedTask;
@@ -52,9 +64,22 @@ public sealed class InMemoryMftIdempotencyStore : IMftIdempotencyStore
     /// <param name="idempotencyKey">Chave composta da transferência.</param>
     /// <param name="reason">Descrição do motivo da falha.</param>
     /// <param name="cancellationToken">Token de cancelamento.</param>
+    /// <exception cref="ArgumentException">
+    /// Lançado quando <paramref name="idempotencyKey"/> ou <paramref name="reason"/> são nulos, vazios ou whitespace.
+    /// </exception>
     public Task MarkFailedAsync(string idempotencyKey, string reason, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            throw new ArgumentException("Chave de idempotência não pode ser nula ou vazia.", nameof(idempotencyKey));
+        }
+
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            throw new ArgumentException("Motivo da falha não pode ser nulo ou vazio.", nameof(reason));
+        }
 
         _state[idempotencyKey] = $"failed:{reason}";
         return Task.CompletedTask;

--- a/src/Nuuvify.CommonPack.MftMailbox/Utilities/RetryExecutor.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox/Utilities/RetryExecutor.cs
@@ -35,7 +35,7 @@ public static class RetryExecutor
         ArgumentNullException.ThrowIfNull(transientPredicate);
         ArgumentNullException.ThrowIfNull(options);
 
-        var random = options.UseJitter ? new Random() : null;
+        var random = options.UseJitter ? Random.Shared : null;
         var attempt = 0;
 
         while (true)

--- a/test/Nuuvify.CommonPack.MftMailbox.xTest/Services/HttpMftMailboxClientInboundTests.cs
+++ b/test/Nuuvify.CommonPack.MftMailbox.xTest/Services/HttpMftMailboxClientInboundTests.cs
@@ -20,43 +20,41 @@ public sealed class HttpMftMailboxClientInboundTests
     [Fact]
     public async Task ReceiveBatchAsync_ComEnvelopeItens_NaoDeveChamarListagemRemota()
     {
-        var responses = new List<HttpResponseMessage>();
+        using var responses = new DisposableHttpResponses();
 
-        try
+        using var handler = new StubHttpMessageHandler(request =>
         {
-            using var handler = new StubHttpMessageHandler(request =>
+            if (request.RequestUri?.AbsolutePath == "/mailbox/list")
             {
-                if (request.RequestUri?.AbsolutePath == "/mailbox/list")
+                throw new InvalidOperationException("List endpoint should not be called when envelope has explicit items.");
+            }
+
+            if (request.RequestUri?.AbsolutePath == "/mailbox/download")
+            {
+                return Task.FromResult(responses.Track(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    throw new InvalidOperationException("List endpoint should not be called when envelope has explicit items.");
-                }
+                    Content = new ByteArrayContent(new byte[] { 1, 2, 3 })
+                }));
+            }
 
-                if (request.RequestUri?.AbsolutePath == "/mailbox/download")
-                {
-                    return Task.FromResult(RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = new ByteArrayContent(new byte[] { 1, 2, 3 })
-                    }));
-                }
+            return Task.FromResult(responses.Track(new HttpResponseMessage(HttpStatusCode.NotFound)));
+        });
 
-                return Task.FromResult(RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.NotFound)));
-            });
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
 
-            using var httpClient = new HttpClient(handler, disposeHandler: false);
+        var client = CreateClient(httpClient, new HttpMftMailboxOptions
+        {
+            BaseUrl = "http://localhost",
+            DownloadPath = "/mailbox/download",
+            ListPath = "/mailbox/list"
+        });
 
-            var client = CreateClient(httpClient, new HttpMftMailboxOptions
-            {
-                BaseUrl = "http://localhost",
-                DownloadPath = "/mailbox/download",
-                ListPath = "/mailbox/list"
-            });
-
-            var envelope = new TransferEnvelope
-            {
-                IntegrationKey = "mainframe-x",
-                CorrelationId = Guid.NewGuid().ToString("N"),
-                Protocol = MftProtocol.Https,
-                Items =
+        var envelope = new TransferEnvelope
+        {
+            IntegrationKey = "mainframe-x",
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            Protocol = MftProtocol.Https,
+            Items =
             {
                 new TransferItem
                 {
@@ -65,32 +63,24 @@ public sealed class HttpMftMailboxClientInboundTests
                     RemotePath = "/inbound/arquivo-c.dat"
                 }
             }
-            };
+        };
 
-            var result = await client.ReceiveBatchAsync(envelope);
+        var result = await client.ReceiveBatchAsync(envelope);
 
-            Assert.Single(result);
-            Assert.Equal("item-001", result.First().ItemId);
-            Assert.Equal("arquivo-c.dat", result.First().FileName);
+        Assert.Single(result);
+        Assert.Equal("item-001", result.First().ItemId);
+        Assert.Equal("arquivo-c.dat", result.First().FileName);
 
-            foreach (var item in result)
-            {
-                await item.DisposeAsync();
-            }
-        }
-        finally
+        foreach (var item in result)
         {
-            foreach (var response in responses)
-            {
-                response.Dispose();
-            }
+            await item.DisposeAsync();
         }
     }
 
     [Fact]
     public async Task ReceiveBatchAsync_ListaRemota_DeveRespeitarOrdenacaoPorNome()
     {
-        var responses = new List<HttpResponseMessage>();
+        using var responses = new DisposableHttpResponses();
 
         var payload = new
         {
@@ -101,69 +91,53 @@ public sealed class HttpMftMailboxClientInboundTests
             }
         };
 
-        try
+        using var handler = new StubHttpMessageHandler(request =>
         {
-            using var handler = new StubHttpMessageHandler(request =>
+            if (request.RequestUri?.AbsolutePath == "/mailbox/list")
             {
-                if (request.RequestUri?.AbsolutePath == "/mailbox/list")
+                return Task.FromResult(responses.Track(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    return Task.FromResult(RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = JsonContent.Create(payload)
-                    }));
-                }
-
-                if (request.RequestUri?.AbsolutePath == "/mailbox/download")
-                {
-                    return Task.FromResult(RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.OK)
-                    {
-                        Content = new ByteArrayContent(DownloadPayload)
-                    }));
-                }
-
-                return Task.FromResult(RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.NotFound)));
-            });
-
-            using var httpClient = new HttpClient(handler, disposeHandler: false);
-
-            var client = CreateClient(httpClient, new HttpMftMailboxOptions
-            {
-                BaseUrl = "http://localhost",
-                DownloadPath = "/mailbox/download",
-                ListPath = "/mailbox/list",
-                InboundFileOrdering = InboundFileOrdering.FileNameAscending
-            });
-
-            var envelope = new TransferEnvelope
-            {
-                IntegrationKey = "mainframe-x",
-                CorrelationId = Guid.NewGuid().ToString("N"),
-                Protocol = MftProtocol.Https
-            };
-
-            var result = await client.ReceiveBatchAsync(envelope);
-            var orderedNames = result.Select(x => x.FileName).ToArray();
-
-            Assert.Equal(new[] { "A-file.txt", "B-file.txt" }, orderedNames);
-
-            foreach (var item in result)
-            {
-                await item.DisposeAsync();
+                    Content = JsonContent.Create(payload)
+                }));
             }
-        }
-        finally
+
+            if (request.RequestUri?.AbsolutePath == "/mailbox/download")
+            {
+                return Task.FromResult(responses.Track(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(DownloadPayload)
+                }));
+            }
+
+            return Task.FromResult(responses.Track(new HttpResponseMessage(HttpStatusCode.NotFound)));
+        });
+
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
+
+        var client = CreateClient(httpClient, new HttpMftMailboxOptions
         {
-            foreach (var response in responses)
-            {
-                response.Dispose();
-            }
-        }
-    }
+            BaseUrl = "http://localhost",
+            DownloadPath = "/mailbox/download",
+            ListPath = "/mailbox/list",
+            InboundFileOrdering = InboundFileOrdering.FileNameAscending
+        });
 
-    private static HttpResponseMessage RegisterResponse(ICollection<HttpResponseMessage> responses, HttpResponseMessage response)
-    {
-        responses.Add(response);
-        return response;
+        var envelope = new TransferEnvelope
+        {
+            IntegrationKey = "mainframe-x",
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            Protocol = MftProtocol.Https
+        };
+
+        var result = await client.ReceiveBatchAsync(envelope);
+        var orderedNames = result.Select(x => x.FileName).ToArray();
+
+        Assert.Equal(new[] { "A-file.txt", "B-file.txt" }, orderedNames);
+
+        foreach (var item in result)
+        {
+            await item.DisposeAsync();
+        }
     }
 
     private static HttpMftMailboxClient CreateClient(HttpClient httpClient, HttpMftMailboxOptions httpOptions)
@@ -191,6 +165,25 @@ public sealed class HttpMftMailboxClientInboundTests
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return _handle(request);
+        }
+    }
+
+    private sealed class DisposableHttpResponses : IDisposable
+    {
+        private readonly List<HttpResponseMessage> _responses = [];
+
+        public HttpResponseMessage Track(HttpResponseMessage response)
+        {
+            _responses.Add(response);
+            return response;
+        }
+
+        public void Dispose()
+        {
+            foreach (var response in _responses)
+            {
+                response.Dispose();
+            }
         }
     }
 }

--- a/test/Nuuvify.CommonPack.MftMailbox.xTest/Services/HttpMftMailboxClientUploadMetadataTests.cs
+++ b/test/Nuuvify.CommonPack.MftMailbox.xTest/Services/HttpMftMailboxClientUploadMetadataTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Nuuvify.CommonPack.MftMailbox.Abstraction.Models;
@@ -17,64 +16,62 @@ public sealed class HttpMftMailboxClientUploadMetadataTests
     [Fact]
     public async Task SendSingleAsync_DeveIncluirMetadadosComPrefixosConfiguradosNoMultipart()
     {
-        var responses = new List<HttpResponseMessage>();
+        using var responses = new DisposableHttpResponses();
         string? multipartBody = null;
         using var uploadContentStream = new MemoryStream(new byte[] { 1, 2, 3 });
 
-        try
+        using var handler = new StubHttpMessageHandler(async request =>
         {
-            using var handler = new StubHttpMessageHandler(async request =>
+            if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/mailbox/upload")
             {
-                if (request.Method == HttpMethod.Post && request.RequestUri?.AbsolutePath == "/mailbox/upload")
-                {
-                    multipartBody = await request.Content!.ReadAsStringAsync();
-                    return RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.OK));
-                }
+                multipartBody = await request.Content!.ReadAsStringAsync();
+                return responses.Track(new HttpResponseMessage(HttpStatusCode.OK));
+            }
 
-                if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/mailbox/status")
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/mailbox/status")
+            {
+                return responses.Track(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    return RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.OK)
+                    Content = JsonContent.Create(new TransferStatus
                     {
-                        Content = JsonContent.Create(new TransferStatus
-                        {
-                            IntegrationKey = "erp-http",
-                            ItemId = "item-001",
-                            State = TransferState.Succeeded
-                        })
-                    });
-                }
+                        IntegrationKey = "erp-http",
+                        ItemId = "item-001",
+                        State = TransferState.Succeeded
+                    })
+                });
+            }
 
-                return RegisterResponse(responses, new HttpResponseMessage(HttpStatusCode.NotFound));
-            });
+            return responses.Track(new HttpResponseMessage(HttpStatusCode.NotFound));
+        });
 
-            using var httpClient = new HttpClient(handler, disposeHandler: false);
-            var client = new HttpMftMailboxClient(
-                httpClient,
-                Options.Create(new HttpMftMailboxOptions
-                {
-                    BaseUrl = "http://localhost",
-                    UploadPath = "/mailbox/upload",
-                    StatusPath = "/mailbox/status",
-                    IncludeMetadataInUploadForm = true,
-                    EnvelopeMetadataFieldPrefix = "env-",
-                    ItemMetadataFieldPrefix = "item-"
-                }),
-                Options.Create(new MftMailboxOptions()),
-                new InMemoryMftIdempotencyStore(),
-                new NullTransferAuditSink(),
-                NullLogger<HttpMftMailboxClient>.Instance);
-
-            var result = await client.SendSingleAsync(new TransferEnvelope
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
+        var client = new HttpMftMailboxClient(
+            httpClient,
+            Options.Create(new HttpMftMailboxOptions
             {
-                IntegrationKey = "erp-http",
-                CorrelationId = Guid.NewGuid().ToString("N"),
-                Protocol = MftProtocol.Https,
-                Metadata = new Dictionary<string, string>
-                {
-                    ["source"] = "sap",
-                    ["batch"] = "42"
-                },
-                Items =
+                BaseUrl = "http://localhost",
+                UploadPath = "/mailbox/upload",
+                StatusPath = "/mailbox/status",
+                IncludeMetadataInUploadForm = true,
+                EnvelopeMetadataFieldPrefix = "env-",
+                ItemMetadataFieldPrefix = "item-"
+            }),
+            Options.Create(new MftMailboxOptions()),
+            new InMemoryMftIdempotencyStore(),
+            new NullTransferAuditSink(),
+            NullLogger<HttpMftMailboxClient>.Instance);
+
+        var result = await client.SendSingleAsync(new TransferEnvelope
+        {
+            IntegrationKey = "erp-http",
+            CorrelationId = Guid.NewGuid().ToString("N"),
+            Protocol = MftProtocol.Https,
+            Metadata = new Dictionary<string, string>
+            {
+                ["source"] = "sap",
+                ["batch"] = "42"
+            },
+            Items =
                 {
                     new TransferItem
                     {
@@ -91,31 +88,17 @@ public sealed class HttpMftMailboxClientUploadMetadataTests
                         }
                     }
                 }
-            });
+        });
 
-            Assert.Equal(TransferState.Succeeded, result.State);
-            Assert.NotNull(multipartBody);
-            Assert.Contains("orders.csv", multipartBody, StringComparison.Ordinal);
-            Assert.Contains("env-", multipartBody, StringComparison.Ordinal);
-            Assert.Contains("sap", multipartBody, StringComparison.Ordinal);
-            Assert.Contains("env-", multipartBody, StringComparison.Ordinal);
-            Assert.Contains("42", multipartBody, StringComparison.Ordinal);
-            Assert.Contains("item-", multipartBody, StringComparison.Ordinal);
-            Assert.Contains("high", multipartBody, StringComparison.Ordinal);
-        }
-        finally
-        {
-            foreach (var response in responses)
-            {
-                response.Dispose();
-            }
-        }
-    }
-
-    private static HttpResponseMessage RegisterResponse(ICollection<HttpResponseMessage> responses, HttpResponseMessage response)
-    {
-        responses.Add(response);
-        return response;
+        Assert.Equal(TransferState.Succeeded, result.State);
+        Assert.NotNull(multipartBody);
+        Assert.Contains("orders.csv", multipartBody, StringComparison.Ordinal);
+        Assert.Contains("env-", multipartBody, StringComparison.Ordinal);
+        Assert.Contains("sap", multipartBody, StringComparison.Ordinal);
+        Assert.Contains("env-", multipartBody, StringComparison.Ordinal);
+        Assert.Contains("42", multipartBody, StringComparison.Ordinal);
+        Assert.Contains("item-", multipartBody, StringComparison.Ordinal);
+        Assert.Contains("high", multipartBody, StringComparison.Ordinal);
     }
 
     private sealed class StubHttpMessageHandler : HttpMessageHandler
@@ -130,6 +113,25 @@ public sealed class HttpMftMailboxClientUploadMetadataTests
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return _handle(request);
+        }
+    }
+
+    private sealed class DisposableHttpResponses : IDisposable
+    {
+        private readonly List<HttpResponseMessage> _responses = [];
+
+        public HttpResponseMessage Track(HttpResponseMessage response)
+        {
+            _responses.Add(response);
+            return response;
+        }
+
+        public void Dispose()
+        {
+            foreach (var response in _responses)
+            {
+                response.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on better resource management in tests, enhanced input validation, and maintaining backward compatibility for logging extensions. Additionally, there are minor project file adjustments.

**Test improvements:**
- Refactored test code in `HttpMftMailboxClientInboundTests.cs` and `HttpMftMailboxClientUploadMetadataTests.cs` to use a new `DisposableHttpResponses` helper for automatic disposal of `HttpResponseMessage` objects, removing manual cleanup and reducing the risk of resource leaks. [[1]](diffhunk://#diff-62fc0a0767f08e8c5600b81e51f64fa74344bf7ca5cd52c0725faec4b549c8a9L23-L26) [[2]](diffhunk://#diff-62fc0a0767f08e8c5600b81e51f64fa74344bf7ca5cd52c0725faec4b549c8a9R170-R188) [[3]](diffhunk://#diff-343df78112487d4f74239b142e32bababdbd2f90898dc6bc793afe18fdeb60a2L20-R33) [[4]](diffhunk://#diff-343df78112487d4f74239b142e32bababdbd2f90898dc6bc793afe18fdeb60a2R118-R136)

**Input validation enhancements:**
- Added explicit checks and exceptions for null, empty, or whitespace `idempotencyKey` and `reason` parameters in `InMemoryMftIdempotencyStore` methods, improving robustness and error reporting. [[1]](diffhunk://#diff-83c8f236a31dbfd57bcc10be3d09572dcbe7a49fa3c9a80b35860229abccde54R28-R37) [[2]](diffhunk://#diff-83c8f236a31dbfd57bcc10be3d09572dcbe7a49fa3c9a80b35860229abccde54R47-R56) [[3]](diffhunk://#diff-83c8f236a31dbfd57bcc10be3d09572dcbe7a49fa3c9a80b35860229abccde54R67-R83)

**Logging extension compatibility:**
- Introduced overloads for `AddNuuvifyConsoleFormatter` in `NuuvifyLogSetupExtensions.cs` to maintain backward compatibility with previous formatter registration patterns.

**Other improvements:**
- Updated random number generation in `RetryExecutor.cs` to use `Random.Shared` for better performance and thread safety.

**Project file adjustments:**
- Removed `<Nullable>enable</Nullable>` from several `.csproj` files, possibly to centralize or change nullability handling. [[1]](diffhunk://#diff-9bf9a278e24b4c9e35581f32fe826f8cb643c0c1206d3492183fe917687b42a6L6) [[2]](diffhunk://#diff-190936216a3405766646d052628708ca424032a7de7c9960c8b3e28065239ac3L6) [[3]](diffhunk://#diff-e1d41855c964e6bb6760ecb2913d5ff7a288a190162cc97c6a72e3c4053af5c3L6) [[4]](diffhunk://#diff-fc0784a73174d6be60e4debe02eb5e2bcde236f499b59ed006f1965304631101L6)…dempotency key validation in services

# Tipo de mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Testes
- [ ] Documentação
- [ ] Breaking change

# Resumo

Descreva objetivamente o problema e a solução proposta.

# Branch de destino

- [ ] `main` para release estável
- [ ] `qas` para preview
- [ ] `nugettest/qas` para build `dev`

# Checklist do autor

- [ ] Li o guia em `CONTRIBUTING.md`
- [ ] O código segue as convenções do projeto e o `.editorconfig`
- [ ] Executei build e os testes relevantes localmente
- [ ] Adicionei ou atualizei testes quando necessário
- [ ] Atualizei documentação e changelog quando necessário
- [ ] Avaliei impacto em compatibilidade, segurança e performance
- [ ] Escolhi a branch de destino correta para o tipo de release esperado

# Evidências

Inclua logs, prints, cobertura, benchmark ou qualquer evidência útil para a revisão.

# Issues relacionadas

Use `Closes #123` ou `Related #123`, quando aplicável.

# Checklist do revisor

- [ ] A alteração está clara, focada e justificada
- [ ] O impacto técnico foi avaliado
- [ ] Os testes cobrem os cenários relevantes
- [ ] A documentação está coerente com a mudança
- [ ] O alvo do PR está alinhado ao canal de release esperado
