### PR TITLE
refactor: update MFT client registration to use keyed transient servi…

### DIFF
--- a/src/Nuuvify.CommonPack.MftMailbox.Http/HttpMftMailboxSetup.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox.Http/HttpMftMailboxSetup.cs
@@ -18,8 +18,9 @@ namespace Nuuvify.CommonPack.MftMailbox.Http;
 /// });
 /// </code>
 /// O <see cref="HttpMftMailboxClient"/> é registrado via <c>AddHttpClient</c> (gerenciado pelo
-/// <c>IHttpClientFactory</c>) e exposto como <see cref="IProtocolMftClient"/> (Singleton)
-/// para resolução pela <c>MftClientFactory</c>.
+/// <c>IHttpClientFactory</c>) e exposto como <see cref="IProtocolMftClient"/> transiente keyed
+/// por <see cref="Nuuvify.CommonPack.MftMailbox.Abstraction.Models.MftProtocol.Https"/>.
+/// A reutilização de instância por protocolo é controlada explicitamente pela <c>MftClientFactory</c>.
 /// </remarks>
 public static class HttpMftMailboxSetup
 {
@@ -37,7 +38,9 @@ public static class HttpMftMailboxSetup
 
         _ = services.Configure(configureOptions);
         _ = services.AddHttpClient<HttpMftMailboxClient>();
-        _ = services.AddSingleton<IProtocolMftClient>(provider => provider.GetRequiredService<HttpMftMailboxClient>());
+        _ = services.AddKeyedTransient<IProtocolMftClient>(
+            Nuuvify.CommonPack.MftMailbox.Abstraction.Models.MftProtocol.Https,
+            (provider, _) => provider.GetRequiredService<HttpMftMailboxClient>());
         return services;
     }
 }

--- a/src/Nuuvify.CommonPack.MftMailbox.Sftp/SftpMftMailboxSetup.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox.Sftp/SftpMftMailboxSetup.cs
@@ -19,8 +19,9 @@ namespace Nuuvify.CommonPack.MftMailbox.Sftp;
 ///     sftp.PrivateKeyPath = "/run/secrets/sftp_key";
 /// });
 /// </code>
-/// O cliente é registrado como Singleton (<see cref="SftpMftMailboxClient"/>) e exposto
-/// como <see cref="IProtocolMftClient"/> para ser resolvido pela <c>MftClientFactory</c>.
+/// O cliente é registrado como <see cref="IProtocolMftClient"/> transiente keyed por
+/// <see cref="Nuuvify.CommonPack.MftMailbox.Abstraction.Models.MftProtocol.Sftp"/>.
+/// A reutilização de instância por protocolo é controlada explicitamente pela <c>MftClientFactory</c>.
 /// </remarks>
 public static class SftpMftMailboxSetup
 {
@@ -37,7 +38,7 @@ public static class SftpMftMailboxSetup
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         _ = services.Configure(configureOptions);
-        _ = services.AddSingleton<IProtocolMftClient, SftpMftMailboxClient>();
+        _ = services.AddKeyedTransient<IProtocolMftClient, SftpMftMailboxClient>(Nuuvify.CommonPack.MftMailbox.Abstraction.Models.MftProtocol.Sftp);
         return services;
     }
 }

--- a/src/Nuuvify.CommonPack.MftMailbox/Configuration/MftMailboxOptions.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox/Configuration/MftMailboxOptions.cs
@@ -1,5 +1,7 @@
 namespace Nuuvify.CommonPack.MftMailbox.Configuration;
 
+using Nuuvify.CommonPack.MftMailbox.Abstraction.Models;
+
 /// <summary>
 /// Opções globais do pacote MftMailbox, compartilhadas por todos os protocolos.
 /// </summary>
@@ -57,4 +59,19 @@ public sealed class MftMailboxOptions
 
     /// <summary>Parâmetros do circuit breaker que protege o servidor MFT de sobrecarga.</summary>
     public CircuitBreakerOptions CircuitBreaker { get; set; } = new();
+
+    /// <summary>
+    /// Protocolos cujas instâncias de cliente serão cacheadas pela <c>MftClientFactory</c>.
+    /// </summary>
+    /// <remarks>
+    /// Por padrão, SFTP e HTTPS são cacheados para preservar estado em memória
+    /// (como circuit breaker e cache local de status). Em APIs/Workers que precisem
+    /// forçar nova criação do cliente HTTPS ao longo do tempo, remova
+    /// <see cref="MftProtocol.Https"/> deste conjunto.
+    /// </remarks>
+    public HashSet<MftProtocol> CachedProtocols { get; set; } =
+    [
+        MftProtocol.Sftp,
+        MftProtocol.Https
+    ];
 }

--- a/src/Nuuvify.CommonPack.MftMailbox/MftMailboxSetup.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox/MftMailboxSetup.cs
@@ -16,6 +16,8 @@ namespace Nuuvify.CommonPack.MftMailbox;
 /// {
 ///     opt.MaxBatchSize = 100;
 ///     opt.Retry.MaxRetries = 5;
+///     // Opcional: desabilitar cache da factory para HTTPS
+///     // opt.CachedProtocols.Remove(MftProtocol.Https);
 /// });
 /// services.AddMftMailboxSftp(sftp =&gt;
 /// {
@@ -41,7 +43,7 @@ public static class MftMailboxSetup
     /// <list type="bullet">
     /// <item><see cref="IMftIdempotencyStore"/> → <see cref="InMemoryMftIdempotencyStore"/> (substitua por implementação persistente em produção).</item>
     /// <item><see cref="ITransferAuditSink"/> → <see cref="NullTransferAuditSink"/> (substitua por implementação de auditoria real).</item>
-    /// <item><see cref="IMftClientFactory"/> → <see cref="MftClientFactory"/>.</item>
+    /// <item><see cref="IMftClientFactory"/> → <see cref="MftClientFactory"/> (com cache explícito por protocolo definido em <see cref="MftMailboxOptions.CachedProtocols"/>).</item>
     /// </list>
     /// </remarks>
     /// <exception cref="ArgumentNullException">

--- a/src/Nuuvify.CommonPack.MftMailbox/Protocols/IProtocolMftClient.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox/Protocols/IProtocolMftClient.cs
@@ -8,8 +8,8 @@ namespace Nuuvify.CommonPack.MftMailbox.Protocols;
 /// </summary>
 /// <remarks>
 /// Implementada pelos clientes concretos (<c>SftpMftMailboxClient</c> e <c>HttpMftMailboxClient</c>).
-/// Registrado no container DI como <c>IProtocolMftClient</c> (singleton) e resolvido pela
-/// <c>MftClientFactory</c> por meio de <see cref="Protocol"/>.
+/// Registrado no container DI como <c>IProtocolMftClient</c> transiente keyed por
+/// <see cref="Protocol"/> e resolvido pela <c>MftClientFactory</c>.
 /// Embora público para suportar registro/resolução entre pacotes, consumidores externos não devem depender diretamente desta interface; use os contratos
 /// individuais (<see cref="IMftTransferClient"/>, <see cref="IMftInboundClient"/>, etc.)
 /// obtidos via <see cref="IMftClientFactory"/>.

--- a/src/Nuuvify.CommonPack.MftMailbox/Services/MftClientFactory.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox/Services/MftClientFactory.cs
@@ -1,5 +1,8 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Nuuvify.CommonPack.MftMailbox.Abstraction.Interfaces;
 using Nuuvify.CommonPack.MftMailbox.Abstraction.Models;
+using Nuuvify.CommonPack.MftMailbox.Configuration;
 using Nuuvify.CommonPack.MftMailbox.Protocols;
 
 namespace Nuuvify.CommonPack.MftMailbox.Services;
@@ -8,35 +11,33 @@ namespace Nuuvify.CommonPack.MftMailbox.Services;
 /// Implementação de <see cref="IMftClientFactory"/> que resolve clientes concretos pelo protocolo.
 /// </summary>
 /// <remarks>
-/// Recebe todos os <see cref="IProtocolMftClient"/> registrados no container DI e os indexa por
-/// <see cref="IProtocolMftClient.Protocol"/>. Registrado como Singleton por
-/// <c>MftMailboxSetup.AddMftMailboxCore</c>. A resolução é O(1) após a construção do índice.
+/// Resolve os clientes por protocolo usando keyed services do DI e mantém cache explícito por
+/// <see cref="MftProtocol"/> para reutilização durante o ciclo de vida da factory.
+/// Registrado como Singleton por <c>MftMailboxSetup.AddMftMailboxCore</c>.
 /// </remarks>
 public sealed class MftClientFactory : IMftClientFactory
 {
-    private readonly IReadOnlyDictionary<MftProtocol, IProtocolMftClient> _clients;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly HashSet<MftProtocol> _cachedProtocols;
+    private readonly Dictionary<MftProtocol, IProtocolMftClient> _cachedClients = new();
+    private readonly object _sync = new();
 
     /// <summary>
-    /// Inicializa a fábrica indexando os clientes fornecidos pelo protocolo.
+    /// Inicializa a fábrica para resolver clientes por protocolo no container DI.
     /// </summary>
-    /// <param name="clients">Coleção de todos os <see cref="IProtocolMftClient"/> registrados no DI.</param>
+    /// <param name="serviceProvider">Provider raiz para resolução de keyed services.</param>
+    /// <param name="options">Opções globais do MFT, incluindo estratégia de cache por protocolo.</param>
     /// <exception cref="InvalidOperationException">
-    /// Lançado quando há mais de um <see cref="IProtocolMftClient"/> registrado para o mesmo <see cref="MftProtocol"/>.
+    /// Lançado quando não há cliente registrado para o protocolo solicitado ou há duplicidade para a mesma chave.
     /// </exception>
-    public MftClientFactory(IEnumerable<IProtocolMftClient> clients)
+    public MftClientFactory(IServiceProvider serviceProvider, IOptions<MftMailboxOptions> options)
     {
-        var dictionary = new Dictionary<MftProtocol, IProtocolMftClient>();
-        foreach (var client in clients)
-        {
-            if (dictionary.ContainsKey(client.Protocol))
-            {
-                throw new InvalidOperationException($"Multiple MFT clients registered for protocol '{client.Protocol}'. Keep only one implementation per protocol.");
-            }
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        ArgumentNullException.ThrowIfNull(options);
 
-            dictionary[client.Protocol] = client;
-        }
-
-        _clients = dictionary;
+        _cachedProtocols = options.Value.CachedProtocols is null
+            ? new HashSet<MftProtocol>()
+            : new HashSet<MftProtocol>(options.Value.CachedProtocols);
     }
 
     /// <inheritdoc />
@@ -53,11 +54,38 @@ public sealed class MftClientFactory : IMftClientFactory
 
     private IProtocolMftClient Resolve(MftProtocol protocol)
     {
-        if (_clients.TryGetValue(protocol, out var client))
+        if (!_cachedProtocols.Contains(protocol))
         {
-            return client;
+            return ResolveProtocolClient(protocol);
         }
 
-        throw new InvalidOperationException($"No MFT client registered for protocol '{protocol}'.");
+        lock (_sync)
+        {
+            if (_cachedClients.TryGetValue(protocol, out var cached))
+            {
+                return cached;
+            }
+
+            var resolved = ResolveProtocolClient(protocol);
+            _cachedClients[protocol] = resolved;
+            return resolved;
+        }
+    }
+
+    private IProtocolMftClient ResolveProtocolClient(MftProtocol protocol)
+    {
+        var keyedClients = _serviceProvider.GetKeyedServices<IProtocolMftClient>(protocol).ToList();
+
+        if (keyedClients.Count == 0)
+        {
+            throw new InvalidOperationException($"No MFT client registered for protocol '{protocol}'.");
+        }
+
+        if (keyedClients.Count > 1)
+        {
+            throw new InvalidOperationException($"Multiple MFT clients registered for protocol '{protocol}'. Keep only one implementation per protocol.");
+        }
+
+        return keyedClients[0];
     }
 }

--- a/test/Nuuvify.CommonPack.MftMailbox.xTest/Services/MftClientFactoryTests.cs
+++ b/test/Nuuvify.CommonPack.MftMailbox.xTest/Services/MftClientFactoryTests.cs
@@ -1,5 +1,8 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Nuuvify.CommonPack.MftMailbox.Abstraction.Interfaces;
 using Nuuvify.CommonPack.MftMailbox.Abstraction.Models;
+using Nuuvify.CommonPack.MftMailbox.Configuration;
 using Nuuvify.CommonPack.MftMailbox.Protocols;
 using Nuuvify.CommonPack.MftMailbox.Services;
 
@@ -11,22 +14,26 @@ public class MftClientFactoryTests
     [Fact]
     public void DeveResolverClientesPorProtocolo()
     {
-        var sftp = new FakeProtocolClient(MftProtocol.Sftp);
-        var https = new FakeProtocolClient(MftProtocol.Https);
+        var services = new ServiceCollection();
+        _ = services.AddKeyedTransient<IProtocolMftClient>(MftProtocol.Sftp, (_, _) => new FakeProtocolClient(MftProtocol.Sftp));
+        _ = services.AddKeyedTransient<IProtocolMftClient>(MftProtocol.Https, (_, _) => new FakeProtocolClient(MftProtocol.Https));
 
-        IMftClientFactory factory = new MftClientFactory(new[] { sftp, https });
+        var provider = services.BuildServiceProvider();
+        IMftClientFactory factory = new MftClientFactory(provider, Options.Create(new MftMailboxOptions()));
 
         var transfer = factory.CreateTransferClient(MftProtocol.Sftp);
         var inbound = factory.CreateInboundClient(MftProtocol.Https);
 
-        Assert.Same(sftp, transfer);
-        Assert.Same(https, inbound);
+        Assert.Equal(MftProtocol.Sftp, ((IProtocolMftClient)transfer).Protocol);
+        Assert.Equal(MftProtocol.Https, ((IProtocolMftClient)inbound).Protocol);
     }
 
     [Fact]
     public void DeveFalharQuandoNaoExisteProtocoloRegistrado()
     {
-        IMftClientFactory factory = new MftClientFactory(Array.Empty<IProtocolMftClient>());
+        var services = new ServiceCollection();
+        var provider = services.BuildServiceProvider();
+        IMftClientFactory factory = new MftClientFactory(provider, Options.Create(new MftMailboxOptions()));
 
         Assert.Throws<InvalidOperationException>(() => factory.CreateTransferClient(MftProtocol.Sftp));
     }
@@ -34,13 +41,53 @@ public class MftClientFactoryTests
     [Fact]
     public void DeveFalharQuandoExisteDuplicidadeDeProtocolo()
     {
-        var first = new FakeProtocolClient(MftProtocol.Sftp);
-        var second = new FakeProtocolClient(MftProtocol.Sftp);
+        var services = new ServiceCollection();
+        _ = services.AddKeyedTransient<IProtocolMftClient>(MftProtocol.Sftp, (_, _) => new FakeProtocolClient(MftProtocol.Sftp));
+        _ = services.AddKeyedTransient<IProtocolMftClient>(MftProtocol.Sftp, (_, _) => new FakeProtocolClient(MftProtocol.Sftp));
+        var provider = services.BuildServiceProvider();
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
-            _ = new MftClientFactory(new[] { first, second }));
+        {
+            IMftClientFactory factory = new MftClientFactory(provider, Options.Create(new MftMailboxOptions()));
+            _ = factory.CreateTransferClient(MftProtocol.Sftp);
+        });
 
         Assert.Contains("Multiple MFT clients registered", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeveCachearInstanciaPorProtocoloMesmoComRegistroTransiente()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddKeyedTransient<IProtocolMftClient>(MftProtocol.Sftp, (_, _) => new FakeProtocolClient(MftProtocol.Sftp));
+
+        var provider = services.BuildServiceProvider();
+        IMftClientFactory factory = new MftClientFactory(provider, Options.Create(new MftMailboxOptions()));
+
+        var first = factory.CreateTransferClient(MftProtocol.Sftp);
+        var second = factory.CreateInboundClient(MftProtocol.Sftp);
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void NaoDeveCachearQuandoProtocoloNaoEstaConfiguradoParaCache()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddKeyedTransient<IProtocolMftClient>(MftProtocol.Https, (_, _) => new FakeProtocolClient(MftProtocol.Https));
+
+        var provider = services.BuildServiceProvider();
+        var options = new MftMailboxOptions
+        {
+            CachedProtocols = [MftProtocol.Sftp]
+        };
+
+        IMftClientFactory factory = new MftClientFactory(provider, Options.Create(options));
+
+        var first = factory.CreateTransferClient(MftProtocol.Https);
+        var second = factory.CreateInboundClient(MftProtocol.Https);
+
+        Assert.NotSame(first, second);
     }
 
     private sealed class FakeProtocolClient : IProtocolMftClient


### PR DESCRIPTION
This pull request introduces a new explicit caching strategy for protocol clients in the MFT Mailbox package, switching from singleton to transient DI registrations and centralizing instance reuse in the `MftClientFactory`. Protocol clients are now registered as keyed transients, and the factory determines which protocols are cached based on configuration. The PR also updates documentation and tests to reflect these changes.

**Dependency Injection and Caching Strategy Updates:**

* Protocol clients (`HttpMftMailboxClient`, `SftpMftMailboxClient`) are now registered as keyed transients rather than singletons, with instance reuse (caching) controlled by `MftClientFactory` according to the new `CachedProtocols` option. (`src/Nuuvify.CommonPack.MftMailbox.Http/HttpMftMailboxSetup.cs` [[1]](diffhunk://#diff-69ed3bf249103f7083e7e9e19e237a295eff1406de2c43376934bb94a5882935L21-R23) [[2]](diffhunk://#diff-69ed3bf249103f7083e7e9e19e237a295eff1406de2c43376934bb94a5882935L40-R43); `src/Nuuvify.CommonPack.MftMailbox.Sftp/SftpMftMailboxSetup.cs` [[3]](diffhunk://#diff-f9835c93b1cceb46033bc717ac17cb93d71ffb19e87660189b4f3ec9277a5eb7L22-R24) [[4]](diffhunk://#diff-f9835c93b1cceb46033bc717ac17cb93d71ffb19e87660189b4f3ec9277a5eb7L40-R41)
* The `MftClientFactory` has been reworked to resolve clients using keyed services from the DI container and to cache instances per protocol only if configured. This change removes the previous approach of relying on singleton DI registrations. (`src/Nuuvify.CommonPack.MftMailbox/Services/MftClientFactory.cs` [[1]](diffhunk://#diff-59815d180718236f484ab4c2c7c399fbd4960721eb42d0c2d88d5a13572c015fR1-R5) [[2]](diffhunk://#diff-59815d180718236f484ab4c2c7c399fbd4960721eb42d0c2d88d5a13572c015fL11-R40) [[3]](diffhunk://#diff-59815d180718236f484ab4c2c7c399fbd4960721eb42d0c2d88d5a13572c015fL56-R90)

**Configuration Enhancements:**

* Added the `CachedProtocols` property to `MftMailboxOptions` to specify which protocols should have their client instances cached by the factory (default: SFTP and HTTPS). This allows for flexible cache control per protocol. (`src/Nuuvify.CommonPack.MftMailbox/Configuration/MftMailboxOptions.cs` [[1]](diffhunk://#diff-ce2d4658050d76baff0afe31f52007dcad5f6757f9a083421699b187c30820aeR3-R4) [[2]](diffhunk://#diff-ce2d4658050d76baff0afe31f52007dcad5f6757f9a083421699b187c30820aeR62-R76)
* Updated documentation and remarks throughout the codebase to clarify the new DI and caching behavior, including guidance on how to disable caching for specific protocols. (`src/Nuuvify.CommonPack.MftMailbox/MftMailboxSetup.cs` [[1]](diffhunk://#diff-ff9e11eac35a9a135f64e632b175d866d824e2bc9fd5ecb431fce27939c2e51dR19-R20) [[2]](diffhunk://#diff-ff9e11eac35a9a135f64e632b175d866d824e2bc9fd5ecb431fce27939c2e51dL44-R46); `src/Nuuvify.CommonPack.MftMailbox/Protocols/IProtocolMftClient.cs` [[3]](diffhunk://#diff-4cbe93be7ae3732cdb1dab106e433e4439a86cba74d54313b9a916947da4a689L11-R12)

**Testing Improvements:**

* Refactored and extended tests to verify the new caching behavior, including tests for cache hits, cache misses, and correct error handling when protocols are missing or duplicated. (`test/Nuuvify.CommonPack.MftMailbox.xTest/Services/MftClientFactoryTests.cs` [[1]](diffhunk://#diff-e3c1d8485fbe0bd6baed77101a0a3dd065ae260086df9303f7ffe865cedba824R1-R5) [[2]](diffhunk://#diff-e3c1d8485fbe0bd6baed77101a0a3dd065ae260086df9303f7ffe865cedba824L14-R92)

These changes improve flexibility, make client lifetime management explicit and configurable, and future-proof the package for scenarios where stateful or stateless protocol clients are needed.…ces and enhance caching logic

# Tipo de mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Testes
- [ ] Documentação
- [ ] Breaking change

# Resumo

Descreva objetivamente o problema e a solução proposta.

# Branch de destino

- [ ] `main` para release estável
- [ ] `qas` para preview
- [ ] `nugettest/qas` para build `dev`

# Checklist do autor

- [ ] Li o guia em `CONTRIBUTING.md`
- [ ] O código segue as convenções do projeto e o `.editorconfig`
- [ ] Executei build e os testes relevantes localmente
- [ ] Adicionei ou atualizei testes quando necessário
- [ ] Atualizei documentação e changelog quando necessário
- [ ] Avaliei impacto em compatibilidade, segurança e performance
- [ ] Escolhi a branch de destino correta para o tipo de release esperado

# Evidências

Inclua logs, prints, cobertura, benchmark ou qualquer evidência útil para a revisão.

# Issues relacionadas

Use `Closes #123` ou `Related #123`, quando aplicável.

# Checklist do revisor

- [ ] A alteração está clara, focada e justificada
- [ ] O impacto técnico foi avaliado
- [ ] Os testes cobrem os cenários relevantes
- [ ] A documentação está coerente com a mudança
- [ ] O alvo do PR está alinhado ao canal de release esperado
