### PR TITLE
refactor: update AckOrNackAsync method to improve response handling a…

### DIFF
--- a/src/Nuuvify.CommonPack.MftMailbox.Http/HttpMftMailboxClient.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox.Http/HttpMftMailboxClient.cs
@@ -205,18 +205,16 @@ public sealed class HttpMftMailboxClient : IProtocolMftClient
     /// </remarks>
     public async Task<TransferItemResult> AckOrNackAsync(AckNackCommand command, CancellationToken cancellationToken = default)
     {
-        var response = await RetryExecutor.ExecuteAsync(
+        _ = await RetryExecutor.ExecuteAsync(
             async () =>
             {
-                var message = await _httpClient.PostAsJsonAsync(_options.AckNackPath, command, cancellationToken).ConfigureAwait(false);
+                using var message = await _httpClient.PostAsJsonAsync(_options.AckNackPath, command, cancellationToken).ConfigureAwait(false);
                 message.EnsureSuccessStatusCode();
-                return message;
+                return true;
             },
             IsTransient,
             _baseOptions.Retry,
             cancellationToken).ConfigureAwait(false);
-
-        response.Dispose();
 
         var result = new TransferItemResult
         {

--- a/src/Nuuvify.CommonPack.MftMailbox/Configuration/MftMailboxOptions.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox/Configuration/MftMailboxOptions.cs
@@ -64,14 +64,14 @@ public sealed class MftMailboxOptions
     /// Protocolos cujas instâncias de cliente serão cacheadas pela <c>MftClientFactory</c>.
     /// </summary>
     /// <remarks>
-    /// Por padrão, SFTP e HTTPS são cacheados para preservar estado em memória
-    /// (como circuit breaker e cache local de status). Em APIs/Workers que precisem
-    /// forçar nova criação do cliente HTTPS ao longo do tempo, remova
-    /// <see cref="MftProtocol.Https"/> deste conjunto.
+    /// Por padrão, apenas SFTP é cacheado para preservar estado de conexão/resiliência.
+    /// HTTPS fica sem cache por padrão para favorecer rotação de handlers e atualização
+    /// de DNS quando o cliente for resolvido repetidamente em APIs/Workers.
+    /// Para manter estado local do cliente HTTP entre chamadas, adicione
+    /// <see cref="MftProtocol.Https"/> explicitamente neste conjunto.
     /// </remarks>
     public HashSet<MftProtocol> CachedProtocols { get; set; } =
     [
-        MftProtocol.Sftp,
-        MftProtocol.Https
+        MftProtocol.Sftp
     ];
 }

--- a/src/Nuuvify.CommonPack.MftMailbox/MftMailboxSetup.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox/MftMailboxSetup.cs
@@ -16,8 +16,8 @@ namespace Nuuvify.CommonPack.MftMailbox;
 /// {
 ///     opt.MaxBatchSize = 100;
 ///     opt.Retry.MaxRetries = 5;
-///     // Opcional: desabilitar cache da factory para HTTPS
-///     // opt.CachedProtocols.Remove(MftProtocol.Https);
+///     // Opcional: habilitar cache da factory para HTTPS
+///     // opt.CachedProtocols.Add(MftProtocol.Https);
 /// });
 /// services.AddMftMailboxSftp(sftp =&gt;
 /// {


### PR DESCRIPTION
This pull request updates the caching behavior for HTTP/S protocols in the mailbox client and improves resource management in the HTTP acknowledgment logic. The main changes are a shift to not cache HTTP/S clients by default—favoring DNS updates and handler rotation—and a refactor to ensure proper disposal of HTTP response messages.

**Caching Behavior Changes:**

* The default for `CachedProtocols` in `MftMailboxOptions` now only includes `MftProtocol.Sftp`. HTTP/S clients are no longer cached by default, which helps ensure DNS changes and handler updates are picked up in long-running services. To cache HTTP/S, it must now be explicitly added.
* Documentation and code comments in `MftMailboxSetup.cs` have been updated to reflect that adding HTTP/S to the cache is now optional and must be done explicitly.

**Resource Management Improvements:**

* The `AckOrNackAsync` method in `HttpMftMailboxClient.cs` now uses a `using` statement to ensure the HTTP response message is properly disposed, and no longer stores the response object, preventing potential resource leaks.…nd modify cached protocols documentation

# Tipo de mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Testes
- [ ] Documentação
- [ ] Breaking change

# Resumo

Descreva objetivamente o problema e a solução proposta.

# Branch de destino

- [ ] `main` para release estável
- [ ] `qas` para preview
- [ ] `nugettest/qas` para build `dev`

# Checklist do autor

- [ ] Li o guia em `CONTRIBUTING.md`
- [ ] O código segue as convenções do projeto e o `.editorconfig`
- [ ] Executei build e os testes relevantes localmente
- [ ] Adicionei ou atualizei testes quando necessário
- [ ] Atualizei documentação e changelog quando necessário
- [ ] Avaliei impacto em compatibilidade, segurança e performance
- [ ] Escolhi a branch de destino correta para o tipo de release esperado

# Evidências

Inclua logs, prints, cobertura, benchmark ou qualquer evidência útil para a revisão.

# Issues relacionadas

Use `Closes #123` ou `Related #123`, quando aplicável.

# Checklist do revisor

- [ ] A alteração está clara, focada e justificada
- [ ] O impacto técnico foi avaliado
- [ ] Os testes cobrem os cenários relevantes
- [ ] A documentação está coerente com a mudança
- [ ] O alvo do PR está alinhado ao canal de release esperado
