### PR TITLE
refactor: implement feature flags for audit stream and status cache i…

### DIFF
--- a/src/Nuuvify.CommonPack.MftMailbox.Redis/Services/RedisAuditStreamSink.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox.Redis/Services/RedisAuditStreamSink.cs
@@ -75,6 +75,11 @@ public sealed class RedisAuditStreamSink : ITransferAuditSink
 
         cancellationToken.ThrowIfCancellationRequested();
 
+        if (!_options.EnableAuditStream)
+        {
+            return;
+        }
+
         try
         {
             var nameValueEntries = _serializer.Serialize(entry);

--- a/src/Nuuvify.CommonPack.MftMailbox.Redis/Services/RedisCachedStatusClient.cs
+++ b/src/Nuuvify.CommonPack.MftMailbox.Redis/Services/RedisCachedStatusClient.cs
@@ -90,6 +90,11 @@ public sealed class RedisCachedStatusClient : IMftStatusClient
 
         cancellationToken.ThrowIfCancellationRequested();
 
+        if (!_options.EnableStatusCache)
+        {
+            return await _innerClient.GetStatusAsync(integrationKey, itemId, cancellationToken).ConfigureAwait(false);
+        }
+
         var cacheKey = BuildCacheKey(integrationKey, itemId);
 
         try

--- a/test/Nuuvify.CommonPack.MftMailbox.Redis.xTest/RedisAuditStreamSinkTests.cs
+++ b/test/Nuuvify.CommonPack.MftMailbox.Redis.xTest/RedisAuditStreamSinkTests.cs
@@ -45,6 +45,24 @@ public class RedisAuditStreamSinkTests
             _serializer,
             _mockLogger.Object);
 
+        _mockDatabase
+            .Setup(db => db.StreamAddAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<NameValueEntry[]>(),
+                It.IsAny<RedisValue?>(),
+                It.IsAny<int?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CommandFlags>()))
+            .ReturnsAsync("1-0");
+
+        _mockDatabase
+            .Setup(db => db.StreamTrimAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<int>(),
+                It.IsAny<bool>(),
+                It.IsAny<CommandFlags>()))
+            .ReturnsAsync(1L);
+
         var entry = new TransferAuditEntry
         {
             IntegrationKey = "integration-1",
@@ -67,6 +85,16 @@ public class RedisAuditStreamSinkTests
             Options.Create(_options),
             _serializer,
             _mockLogger.Object);
+
+        _mockDatabase
+            .Setup(db => db.StreamAddAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<NameValueEntry[]>(),
+                It.IsAny<RedisValue?>(),
+                It.IsAny<int?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CommandFlags>()))
+            .ReturnsAsync("1-0");
 
         // Make mock throw on any method call (simulating Redis connection failure)
         _mockDatabase
@@ -100,6 +128,24 @@ public class RedisAuditStreamSinkTests
             _serializer,
             _mockLogger.Object);
 
+        _mockDatabase
+            .Setup(db => db.StreamAddAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<NameValueEntry[]>(),
+                It.IsAny<RedisValue?>(),
+                It.IsAny<int?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CommandFlags>()))
+            .ReturnsAsync("1-0");
+
+        _mockDatabase
+            .Setup(db => db.StreamTrimAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<int>(),
+                It.IsAny<bool>(),
+                It.IsAny<CommandFlags>()))
+            .ReturnsAsync(1L);
+
         var entry = new TransferAuditEntry
         {
             IntegrationKey = "integration-3",
@@ -122,6 +168,16 @@ public class RedisAuditStreamSinkTests
             Options.Create(_options),
             _serializer,
             _mockLogger.Object);
+
+        _mockDatabase
+            .Setup(db => db.StreamAddAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<NameValueEntry[]>(),
+                It.IsAny<RedisValue?>(),
+                It.IsAny<int?>(),
+                It.IsAny<bool>(),
+                It.IsAny<CommandFlags>()))
+            .ReturnsAsync("1-0");
 
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentNullException>(

--- a/test/Nuuvify.CommonPack.MftMailbox.Redis.xTest/RedisCachedStatusClientTests.cs
+++ b/test/Nuuvify.CommonPack.MftMailbox.Redis.xTest/RedisCachedStatusClientTests.cs
@@ -193,8 +193,6 @@ public class RedisCachedStatusClientTests
     public async Task GetStatusAsync_WithDisabledCache_AlwaysCallsInnerClient()
     {
         // Arrange
-        // Note: Current implementation does not check EnableStatusCache flag in GetStatusAsync
-        // This test documents the actual behavior: cache is always checked, regardless of flag
         _options.EnableStatusCache = false;
 
         var client = new RedisCachedStatusClient(
@@ -228,9 +226,10 @@ public class RedisCachedStatusClientTests
         _mockInnerClient.Verify(
             x => x.GetStatusAsync("integration-4", "item-999", It.IsAny<CancellationToken>()),
             Times.Once);
-        // Cache is checked regardless of EnableStatusCache flag (implementation doesn't check flag)
+
+        // Com cache desabilitado, Redis não deve ser consultado.
         _mockDatabase.Verify(
             x => x.StringGetAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()),
-            Times.Once);
+            Times.Never);
     }
 }

--- a/test/Nuuvify.CommonPack.MftMailbox.xTest/Utilities/ChecksumCalculatorTests.cs
+++ b/test/Nuuvify.CommonPack.MftMailbox.xTest/Utilities/ChecksumCalculatorTests.cs
@@ -1,0 +1,96 @@
+using System.Text;
+using Nuuvify.CommonPack.MftMailbox.Utilities;
+
+namespace Nuuvify.CommonPack.MftMailbox.xTest.Utilities;
+
+[Trait("Category", "Unit")]
+public sealed class ChecksumCalculatorTests
+{
+    [Fact]
+    public async Task Sha256Async_ComConteudoConhecido_DeveRetornarHashEsperado()
+    {
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes("abc"));
+
+        var hash = await ChecksumCalculator.Sha256Async(stream, CancellationToken.None);
+
+        Assert.Equal("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", hash);
+    }
+
+    [Fact]
+    public async Task Sha256Async_ComStreamSeekable_DeveReposicionarNoInicio()
+    {
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes("conteudo"));
+        stream.Position = 3;
+
+        _ = await ChecksumCalculator.Sha256Async(stream, CancellationToken.None);
+
+        Assert.Equal(0, stream.Position);
+    }
+
+    [Fact]
+    public async Task Sha256Async_ComStreamNaoSeekable_DeveCalcularHashSemFalhar()
+    {
+        await using var inner = new MemoryStream(Encoding.UTF8.GetBytes("abc"));
+        await using var stream = new NonSeekableReadStream(inner);
+
+        var hash = await ChecksumCalculator.Sha256Async(stream, CancellationToken.None);
+
+        Assert.Equal("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", hash);
+    }
+
+    private sealed class NonSeekableReadStream : Stream
+    {
+        private readonly Stream _inner;
+
+        public NonSeekableReadStream(Stream inner)
+        {
+            _inner = inner;
+        }
+
+        public override bool CanRead => _inner.CanRead;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => _inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            _inner.ReadAsync(buffer, cancellationToken);
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            _inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await _inner.DisposeAsync();
+            await base.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces feature flags for Redis-based audit stream and status cache operations, ensuring these functionalities can be toggled on or off via configuration. It also adds comprehensive unit tests to validate the new logic and corrects the test suite to reflect the updated behavior. Additionally, a new test class for the `ChecksumCalculator` utility is included.

**Feature flag logic for Redis operations:**

* Added a check for the `EnableAuditStream` option in `RedisAuditStreamSink.WriteAsync`, so audit entries are only written to Redis when enabled.
* Added a check for the `EnableStatusCache` option in `RedisCachedStatusClient.GetStatusAsync`, so the cache is only used if enabled; otherwise, it falls back to the inner client.

**Unit test improvements and corrections:**

* Updated and expanded tests in `RedisAuditStreamSinkTests` to mock Redis operations and verify behavior when the audit stream feature is enabled, disabled, or encounters failures. [[1]](diffhunk://#diff-72ed29a300ed2e1f1d49c61946caea682410c491bb47cb5eafb4750995093046R48-R65) [[2]](diffhunk://#diff-72ed29a300ed2e1f1d49c61946caea682410c491bb47cb5eafb4750995093046R89-R98) [[3]](diffhunk://#diff-72ed29a300ed2e1f1d49c61946caea682410c491bb47cb5eafb4750995093046R131-R148) [[4]](diffhunk://#diff-72ed29a300ed2e1f1d49c61946caea682410c491bb47cb5eafb4750995093046R172-R181)
* Corrected `RedisCachedStatusClientTests` to ensure that with the cache disabled, Redis is not queried and only the inner client is called. [[1]](diffhunk://#diff-027084ce258bc8483af0ef7849ec4b36435c541d90dde62a0f88bab47c92b945L196-L197) [[2]](diffhunk://#diff-027084ce258bc8483af0ef7849ec4b36435c541d90dde62a0f88bab47c92b945L231-R233)

**New utility test coverage:**

* Added `ChecksumCalculatorTests` to verify SHA-256 hash calculation, including edge cases for seekable and non-seekable streams.…n Redis services

# Tipo de mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Testes
- [ ] Documentação
- [ ] Breaking change

# Resumo

Descreva objetivamente o problema e a solução proposta.

# Branch de destino

- [ ] `main` para release estável
- [ ] `qas` para preview
- [ ] `nugettest/qas` para build `dev`

# Checklist do autor

- [ ] Li o guia em `CONTRIBUTING.md`
- [ ] O código segue as convenções do projeto e o `.editorconfig`
- [ ] Executei build e os testes relevantes localmente
- [ ] Adicionei ou atualizei testes quando necessário
- [ ] Atualizei documentação e changelog quando necessário
- [ ] Avaliei impacto em compatibilidade, segurança e performance
- [ ] Escolhi a branch de destino correta para o tipo de release esperado

# Evidências

Inclua logs, prints, cobertura, benchmark ou qualquer evidência útil para a revisão.

# Issues relacionadas

Use `Closes #123` ou `Related #123`, quando aplicável.

# Checklist do revisor

- [ ] A alteração está clara, focada e justificada
- [ ] O impacto técnico foi avaliado
- [ ] Os testes cobrem os cenários relevantes
- [ ] A documentação está coerente com a mudança
- [ ] O alvo do PR está alinhado ao canal de release esperado
