### PR TITLE
feat: ServiceBus

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,11 @@ indent_size = 4
 trim_trailing_whitespace = true
 spelling_exclusion_path = spelling.dic
 
+# YAML files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
 ;========================================================================================================================================================================
 
 # C# files
@@ -271,7 +276,7 @@ dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = priva
 csharp_prefer_static_anonymous_function = true:suggestion
 
 
-## Code Analysis Quality Rules 
+## Code Analysis Quality Rules
 ### Design rules
 #### Do not declare static members on generic types
 dotnet_diagnostic.CA1000.severity = error

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Qual problema queremos resolver?
       description: Explique a dor atual e quem e impactado.
-      placeholder: Ex.: Integracao X exige muito codigo repetido em varios servicos.
+      placeholder: "Ex.: Integracao X exige muito codigo repetido em varios servicos."
     validations:
       required: true
 
@@ -21,7 +21,7 @@ body:
     attributes:
       label: Proposta de solucao
       description: Descreva a ideia principal e suas alternativas.
-      placeholder: Ex.: Criar extensao Y com contrato Z.
+      placeholder: "Ex.: Criar extensao Y com contrato Z."
     validations:
       required: true
 
@@ -30,18 +30,18 @@ body:
     attributes:
       label: Impacto e compatibilidade
       description: Avalie risco de breaking change, migracao e SemVer.
-      placeholder: Ex.: Sem quebra de API publica; apenas adicao backward-compatible.
+      placeholder: "Ex.: Sem quebra de API publica; apenas adicao backward-compatible."
 
   - type: textarea
     id: criterios
     attributes:
       label: Criterios de sucesso
       description: Como medir que a ideia foi bem-sucedida?
-      placeholder: Ex.: Menos boilerplate, menos incidentes, onboarding mais rapido.
+      placeholder: "Ex.: Menos boilerplate, menos incidentes, onboarding mais rapido."
 
   - type: textarea
     id: referencias
     attributes:
       label: Referencias
       description: Links para PRs, issues, docs, benchmarks ou RFCs.
-      placeholder: Ex.: https://github.com/org/repo/issues/123
+      placeholder: "Ex.: https://github.com/org/repo/issues/123"

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,47 @@
+title: "[Ideas] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Proposta de melhoria
+
+        Use esta categoria para propor evolucoes de API, DX, arquitetura e manutencao.
+
+  - type: textarea
+    id: problema
+    attributes:
+      label: Qual problema queremos resolver?
+      description: Explique a dor atual e quem e impactado.
+      placeholder: Ex.: Integracao X exige muito codigo repetido em varios servicos.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposta
+    attributes:
+      label: Proposta de solucao
+      description: Descreva a ideia principal e suas alternativas.
+      placeholder: Ex.: Criar extensao Y com contrato Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impacto
+    attributes:
+      label: Impacto e compatibilidade
+      description: Avalie risco de breaking change, migracao e SemVer.
+      placeholder: Ex.: Sem quebra de API publica; apenas adicao backward-compatible.
+
+  - type: textarea
+    id: criterios
+    attributes:
+      label: Criterios de sucesso
+      description: Como medir que a ideia foi bem-sucedida?
+      placeholder: Ex.: Menos boilerplate, menos incidentes, onboarding mais rapido.
+
+  - type: textarea
+    id: referencias
+    attributes:
+      label: Referencias
+      description: Links para PRs, issues, docs, benchmarks ou RFCs.
+      placeholder: Ex.: https://github.com/org/repo/issues/123

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,41 @@
+title: "[Q&A] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Pergunta tecnica
+
+        Use esta categoria para duvidas objetivas sobre uso dos pacotes, comportamento esperado
+        e troubleshooting.
+
+  - type: textarea
+    id: pergunta
+    attributes:
+      label: Qual e a sua pergunta?
+      description: Descreva de forma objetiva o que voce quer saber.
+      placeholder: Ex.: Como registrar X no DI sem quebrar Y?
+    validations:
+      required: true
+
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Contexto
+      description: Versao do pacote, cenario, stack e restricoes relevantes.
+      placeholder: Ex.: Nuuvify.CommonPack.Security 1.2.3, .NET 8, API ASP.NET Core.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tentativas
+    attributes:
+      label: O que voce ja tentou?
+      description: Liste passos, testes e hipoteses que ja validou.
+      placeholder: Ex.: Tentei A, B e C. Resultado: erro Z.
+
+  - type: textarea
+    id: evidencias
+    attributes:
+      label: Evidencias
+      description: Inclua logs, stack trace, trecho de codigo ou links relevantes.
+      placeholder: Ex.: Cole aqui as mensagens de erro e referencias.

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Qual e a sua pergunta?
       description: Descreva de forma objetiva o que voce quer saber.
-      placeholder: Ex.: Como registrar X no DI sem quebrar Y?
+      placeholder: "Ex.: Como registrar X no DI sem quebrar Y?"
     validations:
       required: true
 
@@ -22,7 +22,7 @@ body:
     attributes:
       label: Contexto
       description: Versao do pacote, cenario, stack e restricoes relevantes.
-      placeholder: Ex.: Nuuvify.CommonPack.Security 1.2.3, .NET 8, API ASP.NET Core.
+      placeholder: "Ex.: Nuuvify.CommonPack.Security 1.2.3, .NET 8, API ASP.NET Core."
     validations:
       required: true
 
@@ -31,11 +31,11 @@ body:
     attributes:
       label: O que voce ja tentou?
       description: Liste passos, testes e hipoteses que ja validou.
-      placeholder: Ex.: Tentei A, B e C. Resultado: erro Z.
+      placeholder: "Ex.: Tentei A, B e C. Resultado: erro Z."
 
   - type: textarea
     id: evidencias
     attributes:
       label: Evidencias
       description: Inclua logs, stack trace, trecho de codigo ou links relevantes.
-      placeholder: Ex.: Cole aqui as mensagens de erro e referencias.
+      placeholder: "Ex.: Cole aqui as mensagens de erro e referencias."

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Resumo
       description: Titulo curto do que voce quer compartilhar.
-      placeholder: Ex.: Implementacao de pipeline de autenticacao com Nuuvify.CommonPack.Security
+      placeholder: "Ex.: Implementacao de pipeline de autenticacao com Nuuvify.CommonPack.Security"
     validations:
       required: true
 
@@ -21,7 +21,7 @@ body:
     attributes:
       label: Cenario
       description: Contexto do projeto e objetivo.
-      placeholder: Ex.: API B2B com multi-tenant e rotacao de credenciais.
+      placeholder: "Ex.: API B2B com multi-tenant e rotacao de credenciais."
     validations:
       required: true
 
@@ -30,7 +30,7 @@ body:
     attributes:
       label: Como foi implementado
       description: Arquitetura, decisoes e trechos relevantes.
-      placeholder: Ex.: Estrutura, DI, estrategias e trade-offs.
+      placeholder: "Ex.: Estrutura, DI, estrategias e trade-offs."
     validations:
       required: true
 
@@ -39,11 +39,11 @@ body:
     attributes:
       label: Resultados e aprendizados
       description: O que funcionou, o que nao funcionou e recomendacoes.
-      placeholder: Ex.: Reducao de erros, ganhos de desempenho, alertas importantes.
+      placeholder: "Ex.: Reducao de erros, ganhos de desempenho, alertas importantes."
 
   - type: textarea
     id: links
     attributes:
       label: Links e anexos
       description: PRs, issues, dashboards, prints ou documentacao.
-      placeholder: Ex.: Links para evidencias e materiais de apoio.
+      placeholder: "Ex.: Links para evidencias e materiais de apoio."

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,49 @@
+title: "[Show and tell] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Compartilhe seu caso
+
+        Use esta categoria para mostrar implementacoes, aprendizados, POCs e resultados.
+
+  - type: input
+    id: resumo
+    attributes:
+      label: Resumo
+      description: Titulo curto do que voce quer compartilhar.
+      placeholder: Ex.: Implementacao de pipeline de autenticacao com Nuuvify.CommonPack.Security
+    validations:
+      required: true
+
+  - type: textarea
+    id: cenario
+    attributes:
+      label: Cenario
+      description: Contexto do projeto e objetivo.
+      placeholder: Ex.: API B2B com multi-tenant e rotacao de credenciais.
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementacao
+    attributes:
+      label: Como foi implementado
+      description: Arquitetura, decisoes e trechos relevantes.
+      placeholder: Ex.: Estrutura, DI, estrategias e trade-offs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: resultados
+    attributes:
+      label: Resultados e aprendizados
+      description: O que funcionou, o que nao funcionou e recomendacoes.
+      placeholder: Ex.: Reducao de erros, ganhos de desempenho, alertas importantes.
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links e anexos
+      description: PRs, issues, dashboards, prints ou documentacao.
+      placeholder: Ex.: Links para evidencias e materiais de apoio.

--- a/docs/maintainers/github-access-governance.md
+++ b/docs/maintainers/github-access-governance.md
@@ -1,0 +1,68 @@
+# Governança de acesso no GitHub
+
+Este procedimento mantém `lzocateli` e `eusener` como os únicos owners da organização `nuuvify` e os únicos administradores do repositório `Nuuvify.CommonPack`. Colaboradores recebem `Write` exclusivamente pelo time `collaborators`.
+
+## Pré-requisitos
+
+- PowerShell 7 ou superior.
+- GitHub CLI disponível no `PATH`.
+- Autenticação no `gh` como `lzocateli` ou `eusener`.
+- Token com acesso administrativo à organização, aos membros, aos times e ao repositório.
+- 2FA e códigos de recuperação protegidos para os dois owners.
+
+Valide a autenticação antes da auditoria:
+
+```powershell
+gh auth status --hostname github.com
+```
+
+## Política declarativa
+
+Edite `tools/scripts/github_access_policy.json` para declarar os membros do time. Não remova `lzocateli` ou `eusener` de `protectedAdministrators` nem de `maintainers`.
+
+Valide o arquivo localmente, sem acessar o GitHub:
+
+```powershell
+./tools/scripts/set-github-access-policy.ps1 -ValidateOnly
+```
+
+## Auditoria
+
+O modo padrão é somente leitura:
+
+```powershell
+./tools/scripts/set-github-access-policy.ps1
+```
+
+Resultados possíveis:
+
+- `OK`: estado atual aderente.
+- `DRIFT`: divergência detectada e não alterada.
+- `CHANGED`: divergência corrigida com `-Apply`.
+- `BLOCKED`: acesso herdado, integração administrativa ou correção que exige intervenção.
+
+Os códigos de saída são `0` para conformidade, `1` para drift em auditoria e `2` para bloqueio.
+
+## Aplicação
+
+Revise todo o relatório de auditoria antes de executar:
+
+```powershell
+./tools/scripts/set-github-access-policy.ps1 -Apply
+```
+
+Owners fora da política não são rebaixados pelo comando anterior. Para autorizá-los explicitamente:
+
+```powershell
+./tools/scripts/set-github-access-policy.ps1 -Apply -ConfirmOwnerDemotion
+```
+
+O script solicitará os logins exibidos, em ordem alfabética e separados por vírgula. Em execução não interativa, informe o mesmo valor em `-OwnerDemotionConfirmation`.
+
+Após aplicar, execute novamente sem `-Apply`. A operação está concluída somente quando não houver `DRIFT` nem `BLOCKED`.
+
+## Limites e rollback
+
+O script não altera políticas do Enterprise, IdP/SCIM, billing managers, security managers nem desinstala GitHub Apps. Esses casos exigem revisão manual.
+
+Para reverter uma alteração, restaure o JSON versionado e execute novamente com `-Apply`. Se um owner tiver sido rebaixado indevidamente, o outro owner protegido deve promovê-lo imediatamente pela interface do GitHub antes de qualquer nova execução.

--- a/docs/maintainers/github-discussions-initial-post.md
+++ b/docs/maintainers/github-discussions-initial-post.md
@@ -1,0 +1,35 @@
+# Bem-vindo ao GitHub Discussions
+
+Este espaco existe para conversas tecnicas e colaboracao da comunidade em torno das bibliotecas Nuuvify.CommonPack.
+
+## Quando usar Discussions
+
+- Duvidas de uso, configuracao e troubleshooting de pacotes
+- Propostas de melhoria e validacao de ideias
+- Compartilhamento de implementacoes, aprendizados e boas praticas
+
+## Quando usar Issues
+
+- Bugs reproduziveis com impacto claro
+- Solicitacoes de feature com escopo de implementacao
+- Tarefas rastreaveis de backlog
+
+## Como escolher a categoria
+
+- Q&A: perguntas objetivas e suporte tecnico
+- Ideas: propostas de evolucao e discussoes de design
+- Show and tell: casos reais, demos e resultados
+
+## Antes de abrir uma discussao
+
+- Verifique se ja existe um topico semelhante
+- Traga contexto minimo (versao, cenario, restricoes)
+- Inclua evidencias quando houver erro (logs, stack trace, links)
+
+## Regras de colaboracao
+
+- Seja objetivo, respeitoso e construtivo
+- Evite expor segredos, tokens ou dados sensiveis
+- Prefira exemplos minimos e reproduziveis
+
+Obrigado por contribuir com a evolucao do ecossistema Nuuvify.CommonPack.

--- a/docs/maintainers/github-setup.md
+++ b/docs/maintainers/github-setup.md
@@ -101,22 +101,63 @@ Quando os checks estiverem aparecendo nos PRs, marque como obrigatórios:
 - `Lint workflows` — somente quando `.github/workflows/**` muda
 - `Validate community assets` — somente quando `.github/**`, `docs/**`, `Readme.md` ou `CHANGELOG.md` mudam
 
-> `Build and unit tests` e `Integration tests` rodam apenas no `publish-release.yml` após o merge, não em PRs.
+Configuração recomendada em `Require status checks to pass before merging`:
+
+- Required: `Version policy check`
+- Required: `Verify package CHANGELOG updated`
+- Não required: `Lint workflows`
+- Não required: `Validate community assets`
+
+Motivo: checks path-filtered podem não executar em todos os PRs; se forem marcados como required, o merge pode ficar bloqueado sem necessidade.
+
+> `Build and unit tests` e `Integration tests` também rodam em PRs (workflow `PR Validation`) e podem rodar novamente no fluxo de publicação.
 
 ## 6.1 Environments e segredos
 
-Crie os environments:
+Onde configurar no GitHub:
+
+- `Settings > Environments`
+
+Crie os environments (botao `New environment`):
 
 - `production`
 - `preview`
 - `nugettest`
 
-Configure os secrets:
+Mapeamento usado pelo workflow `publish-release.yml`:
 
-- `NUGET_API_KEY` para NuGet.org
-- `NUGETTEST_API_KEY` para `https://int.nugettest.org/`
+- branch `main` -> environment `production`
+- branch `qas` -> environment `preview`
+- branch `nugettest/qas` -> environment `nugettest`
 
-Se quiser endurecer a produção, adicione regra de approval no environment `production`.
+Configure os secrets em cada environment:
+
+- Em `production`:
+   - `NUGET_API_KEY` (token do NuGet.org)
+- Em `preview`:
+   - `NUGET_API_KEY` (token do NuGet.org)
+- Em `nugettest`:
+   - `NUGETTEST_API_KEY` (token do `https://int.nugettest.org/`)
+
+Como adicionar secret (por environment):
+
+1. `Settings > Environments > <environment>`
+2. Seção `Environment secrets`
+3. `Add secret`
+4. `Name`: use exatamente o nome esperado pelo workflow
+5. `Value`: cole o token
+6. `Add secret` para salvar
+
+Opcional de governanca:
+
+- Em `production`, configure `Required reviewers` para exigir aprovação antes do job de publish.
+- Se quiser, aplique a mesma proteção em `preview`.
+
+Validacao rapida apos configurar:
+
+1. Rode manualmente `publish-release.yml` via `Actions > Publish and Release > Run workflow` apontando para cada branch.
+2. Confirme no job `Publish packages and release` que o campo `Environment` corresponde ao branch.
+3. Se secret faltar, o job falha com mensagem explicita indicando o nome do secret ausente.
 
 O workflow `Publish and Release` é disparado por `push` em `main`, `qas` e `nugettest/qas`. As branch protections devem impedir push direto para que somente commits aprovados em PR sejam publicados.
 
@@ -130,6 +171,18 @@ Onde configurar:
 
 - `Settings > Secrets and variables > Actions > Variables`
 
+Opcao recomendada para padronizacao entre repositorios:
+
+- Criar em nivel de organizacao: `Organization settings > Secrets and variables > Actions > Variables`
+- Nome: `GH_ACTIONS_UBUNTU_RUNNER`
+- Valor: `ubuntu-24.04`
+- Repositorios com acesso: incluir `Nuuvify.CommonPack` (ou `All repositories`, se fizer sentido para a organizacao)
+
+Precedencia importante:
+
+- Se existir a mesma variavel no repositorio e na organizacao, a variavel do repositorio prevalece.
+- Para evitar ambiguidade, mantenha apenas uma fonte de verdade (organizacao ou repositorio).
+
 Observação operacional:
 
 - Os workflows possuem fallback para `ubuntu-24.04`, mas manter a variável definida facilita upgrades futuros (por exemplo, `ubuntu-26.04`) com uma única alteração.
@@ -142,6 +195,16 @@ Confirme o reconhecimento automático de:
 - `.github/ISSUE_TEMPLATE/feature_request.yml`
 - `.github/ISSUE_TEMPLATE/config.yml`
 - `.github/PULL_REQUEST_TEMPLATE.md`
+
+Para Discussions, confirme também:
+
+- `.github/DISCUSSION_TEMPLATE/q-a.yml`
+- `.github/DISCUSSION_TEMPLATE/ideas.yml`
+- `.github/DISCUSSION_TEMPLATE/show-and-tell.yml`
+
+Para o post inicial fixado, use como base:
+
+- `docs/maintainers/github-discussions-initial-post.md`
 
 ## 8. Merge policy recomendada
 

--- a/docs/maintainers/github-setup.md
+++ b/docs/maintainers/github-setup.md
@@ -235,7 +235,13 @@ Os labels oficiais e suas descrições estão versionados em `.github/labels.yml
 
 Para a operação diária de triagem, consulte também [triage-guide.md](./triage-guide.md).
 
-## 10. Checklist final
+## 10. Governança de acesso
+
+A organização deve manter exatamente `lzocateli` e `eusener` como owners e administradores do repositório. Colaboradores devem receber `Write` pelo time `collaborators`, sem grants humanos diretos.
+
+Para auditar e reconciliar esse estado, siga [github-access-governance.md](./github-access-governance.md).
+
+## 11. Checklist final
 
 - Discussions habilitado
 - Private vulnerability reporting habilitado
@@ -247,8 +253,9 @@ Para a operação diária de triagem, consulte também [triage-guide.md](./triag
 - Checks obrigatórios definidos
 - Environments e secrets configurados
 - Labels iniciais criadas
+- Governança de acesso auditada sem `DRIFT` ou `BLOCKED`
 
-## 11. Automação de labels e triagem
+## 12. Automação de labels e triagem
 
 Depois de subir os arquivos de automação:
 

--- a/docs/plan/github-access-governance-automation-plan.md
+++ b/docs/plan/github-access-governance-automation-plan.md
@@ -1,0 +1,179 @@
+# Plano de automação da governança de acesso no GitHub
+
+## Gestão de Status
+
+| Campo | Valor |
+|---|---|
+| Status | Em andamento |
+| Criado em | 2026-08-06 |
+| Atualizado em | 2026-08-06 |
+| Responsáveis | lzocateli e eusener |
+| Última revisão | 2026-08-06 |
+
+### Histórico de Status
+
+| Data | De -> Para | Motivo |
+|---|---|---|
+| 2026-08-06 | N/A -> Rascunho | Criação do plano para uso posterior |
+| 2026-08-06 | Rascunho -> Rascunho | Inclusão de eusener como corresponsável pelo plano |
+| 2026-08-06 | Rascunho -> Em andamento | Início da implementação com dois owners e administradores protegidos |
+
+## Objetivo
+
+Criar uma automação idempotente em PowerShell usando `gh api`, com modo de auditoria padrão e aplicação explícita, para:
+
+- manter somente `lzocateli` e `eusener` como owners da organização `nuuvify`;
+- manter somente `lzocateli` e `eusener` com administração total do repositório `nuuvify/Nuuvify.CommonPack`;
+- centralizar colaboradores no time `collaborators`, com acesso `Write` somente ao repositório `Nuuvify.CommonPack`;
+- remover acessos humanos diretos não declarados;
+- restringir privilégios gerais dos membros da organização.
+
+## Decisões
+
+- Usar PowerShell 7 e GitHub CLI, sem dependências adicionais.
+- Executar somente auditoria por padrão; alterações exigirão `-Apply`.
+- Exigir confirmação separada e explícita para rebaixar qualquer owner fora da lista protegida.
+- Sincronizar membros do time por arquivo JSON versionado.
+- Definir a permissão-base da organização como `None`.
+- Restringir aos owners a criação de repositórios e times.
+- Preservar `@lzocateli` como único CODEOWNER; `lzocateli` e `eusener` serão os únicos maintainers do time.
+- Auditar GitHub Apps e privilégios herdados do Enterprise, sem removê-los automaticamente.
+
+## Etapas de implementação
+
+1. Criar `tools/scripts/github_access_policy.json` como política declarativa, contendo:
+   - organização `nuuvify`;
+   - owners e administradores protegidos `lzocateli` e `eusener`;
+   - time `collaborators`;
+   - membros autorizados com papel `member`;
+   - repositório `Nuuvify.CommonPack`;
+   - permissão `push`, correspondente a `Write`;
+   - controles organizacionais restritos;
+   - lista explícita de exceções permitidas, quando necessária.
+
+2. Criar `tools/scripts/set-github-access-policy.ps1` com os parâmetros:
+   - `-PolicyPath` para indicar o arquivo de política;
+   - `-Apply` para aplicar correções;
+   - `-ConfirmOwnerDemotion` para permitir o rebaixamento controlado de owners extras.
+   - `-ValidateOnly` para validar localmente a política sem exigir `gh`.
+
+3. Antes de qualquer mutação, validar:
+   - execução com PowerShell 7;
+   - presença do comando `gh`;
+   - autenticação válida do GitHub CLI;
+   - identidade autenticada igual a `lzocateli` ou `eusener`;
+   - papel de owner na organização;
+   - acesso administrativo ao repositório;
+   - permissões suficientes do token para organização e repositório.
+
+4. Implementar uma camada pequena de chamadas REST sobre `gh api`, com:
+   - paginação;
+   - corpos JSON estruturados;
+   - tratamento consistente de respostas `403`, `404` e `422`;
+   - mensagens que não exponham tokens;
+   - operações idempotentes;
+   - estados de relatório `OK`, `DRIFT`, `CHANGED` e `BLOCKED`.
+
+5. Auditar e reconciliar privilégios da organização por `PATCH /orgs/nuuvify`:
+   - `default_repository_permission=none`;
+   - impedir criação de repositórios públicos por membros;
+   - impedir criação de repositórios privados por membros;
+   - impedir criação de repositórios internos por membros, quando aplicável;
+   - impedir criação de times por membros.
+
+6. Auditar owners por `GET /orgs/nuuvify/members?role=admin` e proteger estas invariantes:
+   - `lzocateli` e `eusener` devem estar ativos como owners;
+   - nenhum dos dois pode ser removido ou rebaixado;
+   - qualquer outro owner deve gerar `DRIFT`;
+   - rebaixamento para `member` deve exigir `-Apply`, `-ConfirmOwnerDemotion` e confirmação nominal;
+   - execução não interativa deve exigir um valor explícito de confirmação.
+
+7. Auditar funções organizacionais delegadas:
+   - remover atribuições de organization roles de terceiros quando aplicável;
+   - preservar somente atribuições administrativas de `lzocateli` e `eusener`;
+   - detectar permissões herdadas do Enterprise e retornar `BLOCKED` com sua origem;
+   - auditar billing managers, security managers, GitHub App managers e instalações de GitHub Apps;
+   - não desinstalar Apps automaticamente.
+
+8. Criar ou reconciliar o time `collaborators`:
+   - privacidade `secret`;
+   - notificações habilitadas;
+   - `lzocateli` e `eusener` como únicos maintainers;
+   - demais logins declarados no JSON como `member`;
+   - convites pendentes exibidos no relatório;
+   - membros não declarados removidos quando usado `-Apply`.
+
+9. Conceder ao time somente `Write` no repositório por:
+
+   `PUT /orgs/nuuvify/teams/collaborators/repos/nuuvify/Nuuvify.CommonPack`
+
+10. Auditar todos os times com acesso ao repositório:
+    - remover concessões não declaradas quando usado `-Apply`;
+    - impedir permissões `admin` ou `maintain` para o time de colaboradores;
+    - preservar somente integrações expressamente autorizadas na política.
+
+11. Auditar colaboradores diretos e outside collaborators:
+   - preservar grants administrativos somente de `lzocateli` e `eusener`;
+   - remover grants administrativos diretos dos demais quando usado `-Apply`;
+   - manter colaboradores declarados com `Write` por meio do time;
+   - verificar a permissão efetiva de cada membro autorizado.
+
+12. Executar verificação completa após qualquer aplicação. O comando somente deve terminar com sucesso quando:
+   - existirem exatamente dois owners, `lzocateli` e `eusener`;
+   - apenas `lzocateli` e `eusener` tiverem administração efetiva do repositório;
+   - o time tiver `Write` no repositório;
+   - os membros do time coincidirem com a política;
+   - não houver grants humanos diretos de terceiros;
+   - as políticas organizacionais estiverem restritas;
+   - não houver bloqueios ou fontes de acesso administrativo desconhecidas.
+
+13. Documentar a operação em `docs/maintainers/github-access-governance.md`, incluindo:
+    - pré-requisitos e permissões do token;
+    - modo de auditoria;
+    - modo de aplicação;
+    - confirmação de rebaixamento de owner;
+    - inclusão e remoção de colaboradores pelo JSON;
+    - interpretação de `BLOCKED`;
+    - rollback;
+   - continuidade operacional com exatamente dois owners.
+
+14. Referenciar o guia operacional em `docs/maintainers/github-setup.md`, sem duplicar seu conteúdo.
+
+## Arquivos previstos
+
+- `tools/scripts/set-github-access-policy.ps1`: auditoria e reconciliação via `gh api`.
+- `tools/scripts/github_access_policy.json`: estado desejado de owner, time, membros e permissões.
+- `docs/maintainers/github-access-governance.md`: operação, segurança, validação e rollback.
+- `docs/maintainers/github-setup.md`: referência curta para o procedimento.
+- `.github/CODEOWNERS`: preservar `@lzocateli` como único owner de código.
+- `.github/CONTRIBUTING.md`: revisar somente se for necessário documentar o fluxo interno por time.
+
+## Verificação
+
+1. Validar a sintaxe do script com o parser do PowerShell.
+2. Validar o JSON com `ConvertFrom-Json`.
+3. Executar sem `-Apply` e confirmar que nenhuma chamada mutável foi realizada.
+4. Executar `-Apply` sem confirmação de owner e confirmar que owners extras não foram rebaixados.
+5. Testar o rebaixamento somente em cenário controlado, com confirmação nominal.
+6. Executar novamente em modo de auditoria e exigir apenas estados `OK`.
+7. Conferir na interface do GitHub:
+   - `Organization settings > People`: exatamente `lzocateli` e `eusener` como owners;
+   - `Teams > collaborators`: ambos como únicos maintainers e membros declarados;
+   - `Repository > Settings > Collaborators and teams`: time com `Write` e somente os dois protegidos com `Admin`;
+   - `Organization settings > Member privileges`: políticas restritas.
+8. Cobrir falhas de autenticação, token insuficiente, usuário inexistente, convite pendente, time sincronizado por IdP, papel herdado do Enterprise e App com privilégio administrativo.
+
+## Critérios de conclusão
+
+- O script é idempotente e sua segunda execução não produz mutações.
+- O modo de auditoria nunca altera recursos.
+- Alterações destrutivas exigem consentimento explícito.
+- A política declarativa é a fonte de verdade dos colaboradores.
+- Divergências não corrigíveis retornam código de saída não zero e estado `BLOCKED`.
+- A documentação permite executar, validar e reverter a automação sem consultar seu código interno.
+
+## Limites e riscos
+
+- A política exige exatamente dois owners, `lzocateli` e `eusener`, para continuidade. Ambos devem manter 2FA, passkey ou chave de segurança, códigos de recuperação offline e procedimento de recuperação da conta.
+- Nenhum script garante exclusividade contra um enterprise owner, IdP/SCIM, GitHub App ou política superior que reintroduza acesso. Esses casos devem ser detectados e reportados como `BLOCKED`.
+- A automação não gerenciará branch protections, environments, secrets, billing nem desinstalação automática de GitHub Apps nesta entrega.

--- a/test/Nuuvify.CommonPack.Domain.xTest/ExpressionExtensionTests.cs
+++ b/test/Nuuvify.CommonPack.Domain.xTest/ExpressionExtensionTests.cs
@@ -79,10 +79,22 @@ public class ExpressionExtensionTests
     {
         // Arrange
         var now = DateTimeOffset.Now;
-        var pastTime = now.AddHours(-1); // Uma hora atrás
-        var timeString = pastTime.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
+        var pastTime = now.AddHours(-1).TimeOfDay;
 
-        var expectedTargetTime = DateTimeOffset.Parse($"{now.AddDays(1):yyyy-MM-dd} {timeString}", CultureInfo.InvariantCulture);
+        // Perto da meia-noite, now - 1h pode cair no dia anterior (ex.: 23:30).
+        // Ajusta para garantir um horário que realmente já passou no dia atual.
+        if (pastTime > now.TimeOfDay)
+        {
+            pastTime = now.TimeOfDay.Subtract(TimeSpan.FromMinutes(1));
+        }
+
+        var timeString = pastTime.ToString(@"hh\:mm\:ss", CultureInfo.InvariantCulture);
+
+        var expectedTargetTime = DateTimeOffset.Parse($"{now:yyyy-MM-dd} {timeString}", CultureInfo.InvariantCulture);
+        if (expectedTargetTime <= now)
+        {
+            expectedTargetTime = expectedTargetTime.AddDays(1);
+        }
 
         // Act
         var result = CacheTimeServiceExtension.ExpireAt(timeString);

--- a/test/Nuuvify.CommonPack.Email.xTest/Configs/ServerTestFactAttribute.cs
+++ b/test/Nuuvify.CommonPack.Email.xTest/Configs/ServerTestFactAttribute.cs
@@ -12,7 +12,21 @@ public sealed class ServerTestFactAttribute : FactAttribute
 
     private static bool IsServerMachine()
     {
+        if (IsCiEnvironment())
+        {
+            return false;
+        }
+
         var machineName = Environment.MachineName;
         return !machineName.StartsWith("B8", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsCiEnvironment()
+    {
+        var githubActions = Environment.GetEnvironmentVariable("GITHUB_ACTIONS");
+        var ci = Environment.GetEnvironmentVariable("CI");
+
+        return string.Equals(githubActions, "true", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(ci, "true", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/test/Nuuvify.CommonPack.Email.xTest/EmailTests.cs
+++ b/test/Nuuvify.CommonPack.Email.xTest/EmailTests.cs
@@ -38,6 +38,29 @@ public class EmailTests
 
     }
 
+    private Email CreateIntegrationEmailSender()
+    {
+        var integrationConfiguration = new EmailServerConfiguration();
+
+        new ConfigureFromConfigurationOptions<EmailServerConfiguration>(
+            config.GetSection("EmailConfig:EmailServerConfiguration"))
+            .Configure(integrationConfiguration);
+
+        var (envEmailUsername, envEmailPassword) = _emailConfigFixture.GetEmailCredential(config);
+
+        if (!string.IsNullOrWhiteSpace(envEmailUsername))
+        {
+            integrationConfiguration.AccountUserName = envEmailUsername;
+        }
+
+        if (!string.IsNullOrWhiteSpace(envEmailPassword))
+        {
+            integrationConfiguration.AccountPassword = envEmailPassword;
+        }
+
+        return new Email(integrationConfiguration);
+    }
+
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Nuuvify.CommonPack.Email", nameof(Email))]
@@ -126,7 +149,7 @@ public class EmailTests
         const string assunto = "Teste da classe de envio de email";
         const string mensagem = "Esse é o corpo do email";
 
-        var testarEnvio = new Email(emailServerConfiguration);
+        var testarEnvio = CreateIntegrationEmailSender();
 
         var emailEnviado = await testarEnvio.EnviarAsync(destinatarios, Remetentes, assunto, mensagem);
 
@@ -169,7 +192,7 @@ public class EmailTests
         const string assunto = "Teste da classe de envio de email";
         const string mensagem = "Esse é o corpo do email";
 
-        var testarEnvio = new Email(emailServerConfiguration);
+        var testarEnvio = CreateIntegrationEmailSender();
 
         var emailEnviado = await testarEnvio.EnviarAsync(destinatarios, Remetentes, assunto, mensagem);
 
@@ -312,7 +335,4 @@ public class EmailTests
         Assert.Equal(teste, emailResult);
         Assert.False(testarEnvio.IsValid());
     }
-
 }
-
-

--- a/tools/scripts/github_access_policy.json
+++ b/tools/scripts/github_access_policy.json
@@ -1,0 +1,31 @@
+{
+    "organization": "nuuvify",
+    "repository": "Nuuvify.CommonPack",
+    "protectedAdministrators": [
+        "lzocateli",
+        "eusener"
+    ],
+    "organizationSettings": {
+        "defaultRepositoryPermission": "none",
+        "membersCanCreateRepositories": false,
+        "membersCanCreatePublicRepositories": false,
+        "membersCanCreatePrivateRepositories": false,
+        "membersCanCreateInternalRepositories": false,
+        "membersCanCreateTeams": false
+    },
+    "collaboratorTeam": {
+        "name": "collaborators",
+        "description": "Colaboradores autorizados dos repositorios Nuuvify.",
+        "privacy": "secret",
+        "notificationSetting": "notifications_enabled",
+        "repositoryPermission": "push",
+        "maintainers": [
+            "lzocateli",
+            "eusener"
+        ],
+        "members": []
+    },
+    "allowedRepositoryTeams": [
+        "collaborators"
+    ]
+}

--- a/tools/scripts/set-github-access-policy.ps1
+++ b/tools/scripts/set-github-access-policy.ps1
@@ -1,0 +1,583 @@
+<#
+.SYNOPSIS
+    Audita ou aplica a politica de acesso da organizacao Nuuvify no GitHub.
+
+.DESCRIPTION
+    Usa o GitHub CLI para reconciliar owners da organizacao, privilegios dos membros,
+    time de colaboradores e permissoes do repositorio. Sem -Apply, nenhuma alteracao
+    e executada. O rebaixamento de owners exige confirmacao adicional.
+
+.PARAMETER PolicyPath
+    Caminho do arquivo JSON que descreve o estado desejado.
+
+.PARAMETER Apply
+    Aplica as correcoes encontradas. Sem este parametro, o script apenas audita.
+
+.PARAMETER ConfirmOwnerDemotion
+    Permite rebaixar owners fora da lista protegida para member.
+
+.PARAMETER OwnerDemotionConfirmation
+    Para execucao nao interativa, deve conter os logins a rebaixar, separados por
+    virgula e em ordem alfabetica.
+
+.PARAMETER ValidateOnly
+    Valida somente a estrutura e as invariantes do arquivo de politica, sem exigir gh.
+
+.EXAMPLE
+    ./tools/scripts/set-github-access-policy.ps1
+
+.EXAMPLE
+    ./tools/scripts/set-github-access-policy.ps1 -Apply
+
+.EXAMPLE
+    ./tools/scripts/set-github-access-policy.ps1 -Apply -ConfirmOwnerDemotion
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param (
+    [string]$PolicyPath = (Join-Path $PSScriptRoot 'github_access_policy.json'),
+    [switch]$Apply,
+    [switch]$ConfirmOwnerDemotion,
+    [string]$OwnerDemotionConfirmation,
+    [switch]$ValidateOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:Results = [System.Collections.Generic.List[object]]::new()
+$script:HasBlocked = $false
+$script:HasDrift = $false
+
+function Add-PolicyResult {
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('OK', 'DRIFT', 'CHANGED', 'BLOCKED')]
+        [string]$Status,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Resource,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    $script:Results.Add([pscustomobject]@{
+            Status   = $Status
+            Resource = $Resource
+            Message  = $Message
+        })
+
+    if ($Status -eq 'BLOCKED') {
+        $script:HasBlocked = $true
+    }
+    elseif ($Status -eq 'DRIFT') {
+        $script:HasDrift = $true
+    }
+}
+
+function Invoke-Gh {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+
+        [string]$Body,
+        [switch]$AllowNotFound
+    )
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    $previousGhDockerTty = $env:GH_DOCKER_TTY
+    $hasNativeErrorPreference = $null -ne (Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue)
+    if ($hasNativeErrorPreference) {
+        $previousNativeErrorPreference = $PSNativeCommandUseErrorActionPreference
+    }
+
+    try {
+        $ErrorActionPreference = 'Continue'
+        $env:GH_DOCKER_TTY = '0'
+        if ($hasNativeErrorPreference) {
+            $PSNativeCommandUseErrorActionPreference = $false
+        }
+
+        if ([string]::IsNullOrWhiteSpace($Body)) {
+            $output = ((& gh @Arguments 2>&1) | Out-String).Trim()
+        }
+        else {
+            $output = (($Body | & gh @Arguments --input - 2>&1) | Out-String).Trim()
+        }
+        $exitCode = $LASTEXITCODE
+        $output = [regex]::Replace($output, "`e\][^`a]*(?:`a|`e\\)", '')
+        $output = [regex]::Replace($output, "`e\[[0-?]*[ -/]*[@-~]", '')
+        $output = $output.Trim()
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+        if ($null -eq $previousGhDockerTty) {
+            Remove-Item Env:GH_DOCKER_TTY -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:GH_DOCKER_TTY = $previousGhDockerTty
+        }
+
+        if ($hasNativeErrorPreference) {
+            $PSNativeCommandUseErrorActionPreference = $previousNativeErrorPreference
+        }
+    }
+
+    if ($exitCode -ne 0) {
+        if ($AllowNotFound -and $output -match '(?i)(HTTP 404|Not Found)') {
+            return $null
+        }
+
+        throw "Falha ao executar gh $($Arguments -join ' '): $output"
+    }
+
+    return $output
+}
+
+function Invoke-GhApi {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Endpoint,
+
+        [ValidateSet('GET', 'POST', 'PATCH', 'PUT', 'DELETE')]
+        [string]$Method = 'GET',
+
+        [object]$Body,
+        [switch]$AllowNotFound
+    )
+
+    $arguments = @('api', '--method', $Method, $Endpoint)
+    $json = $null
+    if ($null -ne $Body) {
+        $json = $Body | ConvertTo-Json -Depth 10 -Compress
+    }
+
+    $output = Invoke-Gh -Arguments $arguments -Body $json -AllowNotFound:$AllowNotFound
+    if ([string]::IsNullOrWhiteSpace($output)) {
+        return $null
+    }
+
+    return $output | ConvertFrom-Json
+}
+
+function Invoke-GhApiList {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Endpoint
+    )
+
+    $separator = if ($Endpoint.Contains('?')) { '&' } else { '?' }
+    $arguments = @('api', "$Endpoint${separator}per_page=100", '--paginate', '--slurp')
+    $output = Invoke-Gh -Arguments $arguments
+    if ([string]::IsNullOrWhiteSpace($output)) {
+        return @()
+    }
+
+    $pages = @($output | ConvertFrom-Json)
+    return @($pages | ForEach-Object { @($_) })
+}
+
+function Test-SameSet {
+    param (
+        [string[]]$Actual,
+        [string[]]$Expected
+    )
+
+    $actualNormalized = @($Actual | ForEach-Object { $_.ToLowerInvariant() } | Sort-Object -Unique)
+    $expectedNormalized = @($Expected | ForEach-Object { $_.ToLowerInvariant() } | Sort-Object -Unique)
+    return (($actualNormalized -join '|') -eq ($expectedNormalized -join '|'))
+}
+
+function Test-ProtectedAdministrator {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Login,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$ProtectedAdministrators
+    )
+
+    return $ProtectedAdministrators -contains $Login.ToLowerInvariant()
+}
+
+function Test-WritePermission {
+    param (
+        [Parameter(Mandatory = $true)]
+        [object]$Permissions,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    $permission = $Permissions.PSObject.Properties[$Name]
+    return $null -ne $permission -and $permission.Value -eq 'write'
+}
+
+function Invoke-PolicyMutation {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Resource,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Description,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Action
+    )
+
+    if (-not $Apply) {
+        Add-PolicyResult -Status DRIFT -Resource $Resource -Message $Description
+        return
+    }
+
+    if ($PSCmdlet.ShouldProcess($Resource, $Description)) {
+        & $Action
+        Add-PolicyResult -Status CHANGED -Resource $Resource -Message $Description
+    }
+}
+
+function Get-TeamSlug {
+    param ([Parameter(Mandatory = $true)][string]$Name)
+
+    return $Name.Trim().ToLowerInvariant() -replace '[^a-z0-9]+', '-'
+}
+
+function Assert-Policy {
+    param ([Parameter(Mandatory = $true)][object]$Policy)
+
+    if ([string]::IsNullOrWhiteSpace($Policy.organization) -or
+        [string]::IsNullOrWhiteSpace($Policy.repository)) {
+        throw 'A politica deve informar organization e repository.'
+    }
+
+    if (-not (Test-SameSet -Actual $Policy.protectedAdministrators -Expected @('lzocateli', 'eusener'))) {
+        throw 'A politica deve proteger exatamente os administradores lzocateli e eusener.'
+    }
+
+    if (-not (Test-SameSet -Actual $Policy.collaboratorTeam.maintainers -Expected $Policy.protectedAdministrators)) {
+        throw 'Os maintainers do time devem ser exatamente os administradores protegidos.'
+    }
+
+    if ($Policy.collaboratorTeam.repositoryPermission -ne 'push') {
+        throw "O time de colaboradores deve usar a permissao 'push', correspondente a Write."
+    }
+
+    $teamSlug = Get-TeamSlug -Name $Policy.collaboratorTeam.name
+    $allowedTeamSlugs = @($Policy.allowedRepositoryTeams | ForEach-Object { Get-TeamSlug -Name $_ })
+    if ($allowedTeamSlugs -notcontains $teamSlug) {
+        throw 'O time de colaboradores deve constar em allowedRepositoryTeams.'
+    }
+}
+
+function Assert-Prerequisites {
+    param ([Parameter(Mandatory = $true)][object]$Policy)
+
+    if ($PSVersionTable.PSVersion.Major -lt 7) {
+        throw 'PowerShell 7 ou superior e obrigatorio.'
+    }
+
+    if ($null -eq (Get-Command gh -ErrorAction SilentlyContinue)) {
+        throw 'GitHub CLI (gh) nao foi encontrado no PATH.'
+    }
+
+    Invoke-Gh -Arguments @('auth', 'status', '--hostname', 'github.com') | Out-Null
+    $authenticatedLogin = [string](Invoke-Gh -Arguments @('api', 'user', '--jq', '.login'))
+    $authenticatedLogin = $authenticatedLogin.Trim().ToLowerInvariant()
+    [string[]]$protectedAdministrators = @(
+        $Policy.protectedAdministrators | ForEach-Object { ([string]$_).Trim().ToLowerInvariant() }
+    )
+
+    Write-Host "Conta autenticada: $authenticatedLogin"
+    Write-Host "Organizacao: $($Policy.organization)"
+    Write-Host "Repositorio: $($Policy.organization)/$($Policy.repository)"
+    Write-Host "Administradores protegidos: $($protectedAdministrators -join ', ')"
+
+    $isProtectedAdministrator = $false
+    foreach ($protectedAdministrator in $protectedAdministrators) {
+        if ([string]::Equals(
+                $protectedAdministrator,
+                $authenticatedLogin,
+                [System.StringComparison]::OrdinalIgnoreCase)) {
+            $isProtectedAdministrator = $true
+            break
+        }
+    }
+
+    if (-not $isProtectedAdministrator) {
+        throw "A conta autenticada '$authenticatedLogin' nao pertence a lista de administradores protegidos."
+    }
+
+    $membership = Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/memberships/$authenticatedLogin"
+    if ($membership.state -ne 'active' -or $membership.role -ne 'admin') {
+        throw "A conta '$authenticatedLogin' deve ser owner ativo da organizacao '$($Policy.organization)'."
+    }
+
+    $permission = Invoke-GhApi -Endpoint "repos/$($Policy.organization)/$($Policy.repository)/collaborators/$authenticatedLogin/permission"
+    if ($permission.permission -ne 'admin') {
+        throw "A conta '$authenticatedLogin' deve ter Admin no repositorio '$($Policy.repository)'."
+    }
+
+    Add-PolicyResult -Status OK -Resource 'authentication' -Message "Autenticado como owner protegido '$authenticatedLogin'."
+}
+
+function Sync-OrganizationSettings {
+    param ([Parameter(Mandatory = $true)][object]$Policy)
+
+    $organization = Invoke-GhApi -Endpoint "orgs/$($Policy.organization)"
+    $desired = $Policy.organizationSettings
+    $drift =
+    $organization.default_repository_permission -ne $desired.defaultRepositoryPermission -or
+    $organization.members_can_create_repositories -ne $desired.membersCanCreateRepositories -or
+    $organization.members_can_create_public_repositories -ne $desired.membersCanCreatePublicRepositories -or
+    $organization.members_can_create_private_repositories -ne $desired.membersCanCreatePrivateRepositories -or
+    $organization.members_can_create_teams -ne $desired.membersCanCreateTeams
+
+    if (-not $drift) {
+        Add-PolicyResult -Status OK -Resource 'organization settings' -Message 'Privilegios gerais dos membros estao restritos.'
+        return
+    }
+
+    $body = @{
+        default_repository_permission           = $desired.defaultRepositoryPermission
+        members_can_create_repositories         = $desired.membersCanCreateRepositories
+        members_can_create_public_repositories  = $desired.membersCanCreatePublicRepositories
+        members_can_create_private_repositories = $desired.membersCanCreatePrivateRepositories
+        members_can_create_teams                = $desired.membersCanCreateTeams
+    }
+    if ($organization.plan.name -eq 'enterprise') {
+        $body.members_can_create_internal_repositories = $desired.membersCanCreateInternalRepositories
+    }
+
+    Invoke-PolicyMutation -Resource "organization/$($Policy.organization)" -Description 'Restringir privilegios gerais dos membros.' -Action {
+        Invoke-GhApi -Endpoint "orgs/$($Policy.organization)" -Method PATCH -Body $body | Out-Null
+    }
+}
+
+function Sync-OrganizationOwners {
+    param ([Parameter(Mandatory = $true)][object]$Policy)
+
+    $protected = @($Policy.protectedAdministrators | ForEach-Object { $_.ToLowerInvariant() })
+    $owners = @(Invoke-GhApiList -Endpoint "orgs/$($Policy.organization)/members?role=admin")
+    $ownerLogins = @($owners.login | ForEach-Object { $_.ToLowerInvariant() })
+
+    foreach ($login in $protected) {
+        if ($ownerLogins -contains $login) {
+            Add-PolicyResult -Status OK -Resource "owner/$login" -Message 'Owner protegido esta ativo.'
+            continue
+        }
+
+        Invoke-PolicyMutation -Resource "owner/$login" -Description 'Promover usuario protegido para owner.' -Action {
+            Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/memberships/$login" -Method PUT -Body @{ role = 'admin' } | Out-Null
+        }
+    }
+
+    $extraOwners = @($ownerLogins | Where-Object { $protected -notcontains $_ } | Sort-Object)
+    if ($extraOwners.Count -eq 0) {
+        return
+    }
+
+    $expectedConfirmation = $extraOwners -join ','
+    $confirmation = $OwnerDemotionConfirmation
+    if ($Apply -and $ConfirmOwnerDemotion -and [string]::IsNullOrWhiteSpace($confirmation)) {
+        $confirmation = Read-Host "Confirme os owners que serao rebaixados digitando: $expectedConfirmation"
+    }
+
+    foreach ($login in $extraOwners) {
+        if (-not $Apply) {
+            Add-PolicyResult -Status DRIFT -Resource "owner/$login" -Message 'Owner fora da lista protegida deve ser rebaixado para member.'
+            continue
+        }
+
+        if (-not $ConfirmOwnerDemotion) {
+            Add-PolicyResult -Status BLOCKED -Resource "owner/$login" -Message 'Use -ConfirmOwnerDemotion para autorizar o rebaixamento.'
+            continue
+        }
+
+        if ($confirmation.Trim().ToLowerInvariant() -ne $expectedConfirmation) {
+            Add-PolicyResult -Status BLOCKED -Resource "owner/$login" -Message 'Confirmacao nominal dos owners nao corresponde ao esperado.'
+            continue
+        }
+
+        Invoke-PolicyMutation -Resource "owner/$login" -Description 'Rebaixar owner nao autorizado para member.' -Action {
+            Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/memberships/$login" -Method PUT -Body @{ role = 'member' } | Out-Null
+        }
+    }
+}
+
+function Sync-CollaboratorTeam {
+    param ([Parameter(Mandatory = $true)][object]$Policy)
+
+    $team = $Policy.collaboratorTeam
+    $teamSlug = Get-TeamSlug -Name $team.name
+    $currentTeam = Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/teams/$teamSlug" -AllowNotFound
+
+    if ($null -eq $currentTeam) {
+        Invoke-PolicyMutation -Resource "team/$teamSlug" -Description 'Criar time de colaboradores.' -Action {
+            Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/teams" -Method POST -Body @{
+                name                 = $team.name
+                description          = $team.description
+                privacy              = $team.privacy
+                notification_setting = $team.notificationSetting
+            } | Out-Null
+        }
+        if (-not $Apply) {
+            return
+        }
+        $currentTeam = Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/teams/$teamSlug"
+    }
+
+    $teamDrift =
+    $currentTeam.description -ne $team.description -or
+    $currentTeam.privacy -ne $team.privacy -or
+    $currentTeam.notification_setting -ne $team.notificationSetting
+    if ($teamDrift) {
+        Invoke-PolicyMutation -Resource "team/$teamSlug" -Description 'Atualizar configuracao do time de colaboradores.' -Action {
+            Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/teams/$teamSlug" -Method PATCH -Body @{
+                name                 = $team.name
+                description          = $team.description
+                privacy              = $team.privacy
+                notification_setting = $team.notificationSetting
+            } | Out-Null
+        }
+    }
+    else {
+        Add-PolicyResult -Status OK -Resource "team/$teamSlug" -Message 'Configuracao do time esta correta.'
+    }
+
+    $desiredMaintainers = @($team.maintainers | ForEach-Object { $_.ToLowerInvariant() })
+    $desiredMembers = @($team.members | ForEach-Object { $_.ToLowerInvariant() })
+    $desiredUsers = @($desiredMaintainers + $desiredMembers | Sort-Object -Unique)
+    $currentMembers = @(Invoke-GhApiList -Endpoint "orgs/$($Policy.organization)/teams/$teamSlug/members")
+    $currentLogins = @($currentMembers.login | ForEach-Object { $_.ToLowerInvariant() })
+
+    foreach ($login in $desiredUsers) {
+        $desiredRole = if ($desiredMaintainers -contains $login) { 'maintainer' } else { 'member' }
+        $membership = Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/teams/$teamSlug/memberships/$login" -AllowNotFound
+        if ($null -ne $membership -and $membership.role -eq $desiredRole) {
+            Add-PolicyResult -Status OK -Resource "team-member/$login" -Message "Papel '$desiredRole' esta correto."
+            continue
+        }
+
+        Invoke-PolicyMutation -Resource "team-member/$login" -Description "Definir papel '$desiredRole' no time." -Action {
+            Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/teams/$teamSlug/memberships/$login" -Method PUT -Body @{ role = $desiredRole } | Out-Null
+        }
+    }
+
+    foreach ($login in @($currentLogins | Where-Object { $desiredUsers -notcontains $_ })) {
+        Invoke-PolicyMutation -Resource "team-member/$login" -Description 'Remover usuario nao declarado do time.' -Action {
+            Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/teams/$teamSlug/memberships/$login" -Method DELETE | Out-Null
+        }
+    }
+
+    $repositoryPermission = Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/teams/$teamSlug/repos/$($Policy.organization)/$($Policy.repository)" -AllowNotFound
+    if ($null -ne $repositoryPermission -and $repositoryPermission.role_name -eq 'write') {
+        Add-PolicyResult -Status OK -Resource "team-repository/$teamSlug" -Message 'Time possui Write no repositorio.'
+    }
+    else {
+        Invoke-PolicyMutation -Resource "team-repository/$teamSlug" -Description 'Conceder Write ao time no repositorio.' -Action {
+            Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/teams/$teamSlug/repos/$($Policy.organization)/$($Policy.repository)" -Method PUT -Body @{ permission = $team.repositoryPermission } | Out-Null
+        }
+    }
+}
+
+function Sync-RepositoryAccess {
+    param ([Parameter(Mandatory = $true)][object]$Policy)
+
+    $protected = @($Policy.protectedAdministrators | ForEach-Object { $_.ToLowerInvariant() })
+    $allowedTeams = @($Policy.allowedRepositoryTeams | ForEach-Object { Get-TeamSlug -Name $_ })
+    $teams = @(Invoke-GhApiList -Endpoint "repos/$($Policy.organization)/$($Policy.repository)/teams")
+    foreach ($team in $teams) {
+        if ($allowedTeams -contains $team.slug.ToLowerInvariant()) {
+            continue
+        }
+
+        Invoke-PolicyMutation -Resource "repository-team/$($team.slug)" -Description 'Remover time nao autorizado do repositorio.' -Action {
+            Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/teams/$($team.slug)/repos/$($Policy.organization)/$($Policy.repository)" -Method DELETE | Out-Null
+        }
+    }
+
+    $directCollaborators = @(Invoke-GhApiList -Endpoint "repos/$($Policy.organization)/$($Policy.repository)/collaborators?affiliation=direct")
+    foreach ($collaborator in $directCollaborators) {
+        $login = $collaborator.login.ToLowerInvariant()
+        if (Test-ProtectedAdministrator -Login $login -ProtectedAdministrators $protected) {
+            continue
+        }
+
+        Invoke-PolicyMutation -Resource "repository-collaborator/$login" -Description 'Remover grant direto; acesso autorizado deve vir do time.' -Action {
+            Invoke-GhApi -Endpoint "repos/$($Policy.organization)/$($Policy.repository)/collaborators/$login" -Method DELETE | Out-Null
+        }
+    }
+
+    $administrators = @(Invoke-GhApiList -Endpoint "repos/$($Policy.organization)/$($Policy.repository)/collaborators?permission=admin")
+    foreach ($administrator in $administrators) {
+        $login = $administrator.login.ToLowerInvariant()
+        if (-not (Test-ProtectedAdministrator -Login $login -ProtectedAdministrators $protected)) {
+            Add-PolicyResult -Status BLOCKED -Resource "repository-admin/$login" -Message 'Usuario ainda possui Admin por fonte efetiva; revisar time, Enterprise ou role customizada.'
+        }
+    }
+}
+
+function Audit-AdministrativeIntegrations {
+    param ([Parameter(Mandatory = $true)][object]$Policy)
+
+    try {
+        $installationsResponse = Invoke-GhApi -Endpoint "orgs/$($Policy.organization)/installations"
+        foreach ($installation in @($installationsResponse.installations)) {
+            $hasAdministrativeAccess =
+            (Test-WritePermission -Permissions $installation.permissions -Name 'administration') -or
+            (Test-WritePermission -Permissions $installation.permissions -Name 'organization_administration') -or
+            (Test-WritePermission -Permissions $installation.permissions -Name 'members')
+            if ($hasAdministrativeAccess) {
+                Add-PolicyResult -Status BLOCKED -Resource "github-app/$($installation.app_slug)" -Message 'GitHub App possui permissao administrativa; revisar manualmente.'
+            }
+        }
+    }
+    catch {
+        Add-PolicyResult -Status BLOCKED -Resource 'github-apps' -Message "Nao foi possivel auditar instalacoes: $($_.Exception.Message)"
+    }
+}
+
+function Write-PolicyReport {
+    $script:Results | Format-Table -AutoSize -Wrap
+
+    $summary = $script:Results | Group-Object Status | Sort-Object Name
+    Write-Host ''
+    Write-Host 'Resumo:'
+    foreach ($item in $summary) {
+        Write-Host "  $($item.Name): $($item.Count)"
+    }
+}
+
+if (-not (Test-Path -LiteralPath $PolicyPath -PathType Leaf)) {
+    throw "Arquivo de politica nao encontrado: $PolicyPath"
+}
+
+$policy = Get-Content -LiteralPath $PolicyPath -Raw | ConvertFrom-Json
+$policy.protectedAdministrators = [string[]]@(
+    $policy.protectedAdministrators | ForEach-Object { ([string]$_).Trim().ToLowerInvariant() }
+)
+Assert-Policy -Policy $policy
+
+if ($ValidateOnly) {
+    Write-Host "Politica valida: $PolicyPath"
+    exit 0
+}
+
+Assert-Prerequisites -Policy $policy
+Sync-OrganizationSettings -Policy $policy
+Sync-OrganizationOwners -Policy $policy
+Sync-CollaboratorTeam -Policy $policy
+Sync-RepositoryAccess -Policy $policy
+Audit-AdministrativeIntegrations -Policy $policy
+Write-PolicyReport
+
+if ($script:HasBlocked) {
+    exit 2
+}
+
+if ($script:HasDrift -and -not $Apply) {
+    exit 1
+}
+
+exit 0


### PR DESCRIPTION
This pull request introduces significant improvements to the repository’s governance, automation, and documentation for GitHub access and community collaboration. The main themes are: (1) automation and documentation of GitHub access governance, (2) enhancements to the maintainers’ setup guide, and (3) addition of structured GitHub Discussions templates and onboarding documentation.

**Key changes:**

### GitHub Access Governance Automation

* Added a comprehensive plan for automating GitHub organization and repository access governance, detailing requirements, implementation steps, and verification criteria in `docs/plan/github-access-governance-automation-plan.md`.
* Introduced a step-by-step operational guide for auditing and enforcing access policies, including owner and collaborator management, in `docs/maintainers/github-access-governance.md`.
* Updated `docs/maintainers/github-setup.md` to reference and integrate the new governance process, including a dedicated section and checklist updates to ensure compliance. [[1]](diffhunk://#diff-36f1c1d699ffd7a0fd37dc8de7ae298efdfcfe995fd4ed3ea63356f4c6e80e35L175-R244) [[2]](diffhunk://#diff-36f1c1d699ffd7a0fd37dc8de7ae298efdfcfe995fd4ed3ea63356f4c6e80e35R256-R258)

### GitHub Discussions and Community Onboarding

* Added three structured GitHub Discussions templates for Q&A, Ideas, and Show and Tell, improving the onboarding and categorization of community discussions (`.github/DISCUSSION_TEMPLATE/q-a.yml`, `.github/DISCUSSION_TEMPLATE/ideas.yml`, `.github/DISCUSSION_TEMPLATE/show-and-tell.yml`). [[1]](diffhunk://#diff-88f0e200170c19834e4173955892be240b58b64bde6139cd3322a11afe1255ffR1-R41) [[2]](diffhunk://#diff-25fb384d56a2e88d015f3f06a4a7cf5b39caf40e05c25dbd57364ea03436e344R1-R47) [[3]](diffhunk://#diff-3bec9ce19e4e6d9434222a806b3f800bbbde5dee5d3263f1393fc10cd3c78b55R1-R49)
* Created an initial post template in `docs/maintainers/github-discussions-initial-post.md` to guide community engagement and clarify the use of Discussions versus Issues.
* Updated the setup guide to include recognition of Discussions templates and the initial post.

### Documentation and Workflow Improvements

* Improved documentation for status checks, environment setup, and secret/variable management in `docs/maintainers/github-setup.md`, including recommendations for required checks and environment/secret mapping, and guidance for organization-level variables. [[1]](diffhunk://#diff-36f1c1d699ffd7a0fd37dc8de7ae298efdfcfe995fd4ed3ea63356f4c6e80e35L104-R160) [[2]](diffhunk://#diff-36f1c1d699ffd7a0fd37dc8de7ae298efdfcfe995fd4ed3ea63356f4c6e80e35R174-R185)
* Enhanced `.editorconfig` to enforce 2-space indentation for YAML files, ensuring consistency across configuration files.

These changes collectively strengthen repository security, clarify governance, streamline onboarding for contributors, and improve the developer experience.# Tipo de mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Testes
- [ ] Documentação
- [ ] Breaking change

# Resumo

Descreva objetivamente o problema e a solução proposta.

# Branch de destino

- [ ] `main` para release estável
- [ ] `qas` para preview
- [ ] `nugettest/qas` para build `dev`

# Checklist do autor

- [ ] Li o guia em `CONTRIBUTING.md`
- [ ] O código segue as convenções do projeto e o `.editorconfig`
- [ ] Executei build e os testes relevantes localmente
- [ ] Adicionei ou atualizei testes quando necessário
- [ ] Atualizei documentação e changelog quando necessário
- [ ] Avaliei impacto em compatibilidade, segurança e performance
- [ ] Escolhi a branch de destino correta para o tipo de release esperado

# Evidências

Inclua logs, prints, cobertura, benchmark ou qualquer evidência útil para a revisão.

# Issues relacionadas

Use `Closes #123` ou `Related #123`, quando aplicável.

# Checklist do revisor

- [ ] A alteração está clara, focada e justificada
- [ ] O impacto técnico foi avaliado
- [ ] Os testes cobrem os cenários relevantes
- [ ] A documentação está coerente com a mudança
- [ ] O alvo do PR está alinhado ao canal de release esperado
